### PR TITLE
Rhs assembly alone

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -39,9 +39,9 @@ version = "0.15.3"
 
 [[ChainRulesCore]]
 deps = ["Compat", "LinearAlgebra", "SparseArrays"]
-git-tree-sha1 = "74e8234fb738c45e2af55fdbcd9bfbe00c2446fa"
+git-tree-sha1 = "2f294fae04aa5069a67964a3366e151e09ea7c09"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.8.0"
+version = "1.9.0"
 
 [[CodecZlib]]
 deps = ["TranscodingStreams", "Zlib_jll"]
@@ -139,10 +139,10 @@ uuid = "6a86dc24-6348-571c-b903-95158fe2bd41"
 version = "2.8.1"
 
 [[ForwardDiff]]
-deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "LinearAlgebra", "NaNMath", "Printf", "Random", "SpecialFunctions", "StaticArrays"]
-git-tree-sha1 = "c4203b60d37059462af370c4f3108fb5d155ff13"
+deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "LinearAlgebra", "NaNMath", "Preferences", "Printf", "Random", "SpecialFunctions", "StaticArrays"]
+git-tree-sha1 = "63777916efbcb0ab6173d09a658fb7f2783de485"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
-version = "0.10.20"
+version = "0.10.21"
 
 [[Gridap]]
 deps = ["AbstractTrees", "BSON", "BlockArrays", "Combinatorics", "DocStringExtensions", "FastGaussQuadrature", "FileIO", "FillArrays", "ForwardDiff", "JLD2", "JSON", "LineSearches", "LinearAlgebra", "NLsolve", "NearestNeighbors", "QuadGK", "Random", "SparseArrays", "SparseMatricesCSR", "StaticArrays", "Test", "WriteVTK"]
@@ -230,9 +230,9 @@ uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [[MPI]]
 deps = ["Distributed", "DocStringExtensions", "Libdl", "MPICH_jll", "MicrosoftMPI_jll", "OpenMPI_jll", "Pkg", "Random", "Requires", "Serialization", "Sockets"]
-git-tree-sha1 = "e4549a5ced642a73bd8ba2dd1d3b1d30b3530d94"
+git-tree-sha1 = "340d8dc89e1c85a846d3f38ee294bfdd1684055a"
 uuid = "da04e1cc-30fd-572f-bb4f-1f8673147195"
-version = "0.19.0"
+version = "0.19.1"
 
 [[MPICH_jll]]
 deps = ["CompilerSupportLibraries_jll", "Libdl", "Pkg"]
@@ -313,9 +313,9 @@ version = "0.12.3"
 
 [[Parsers]]
 deps = ["Dates"]
-git-tree-sha1 = "a8709b968a1ea6abc2dc1967cb1db6ac9a00dfb6"
+git-tree-sha1 = "98f59ff3639b3d9485a03a72f3ab35bab9465720"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "2.0.5"
+version = "2.0.6"
 
 [[PartitionedArrays]]
 deps = ["IterativeSolvers", "LinearAlgebra", "MPI", "Printf", "SparseArrays", "SparseMatricesCSR"]

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -5,23 +5,23 @@ git-tree-sha1 = "03e0550477d86222521d254b741d470ba17ea0b5"
 uuid = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 version = "0.3.4"
 
+[[ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+
 [[ArrayInterface]]
 deps = ["Compat", "IfElse", "LinearAlgebra", "Requires", "SparseArrays", "Static"]
-git-tree-sha1 = "b8d49c34c3da35f220e7295659cd0bab8e739fed"
+git-tree-sha1 = "1d6835607e9f214cb4210310868f8cf07eb0facc"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "3.1.33"
+version = "3.1.34"
 
 [[ArrayLayouts]]
 deps = ["FillArrays", "LinearAlgebra", "SparseArrays"]
-git-tree-sha1 = "623a32b87ef0b85d26320a8cc7e57ded707aef64"
+git-tree-sha1 = "7a92ea1dd16472d18ca1ffcbb7b3cc67d7e78a3f"
 uuid = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
-version = "0.7.5"
+version = "0.7.7"
 
 [[Artifacts]]
-deps = ["Pkg"]
-git-tree-sha1 = "c30985d8821e0cd73870b17b0ed0ce6dc44cb744"
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
-version = "1.3.0"
 
 [[BSON]]
 git-tree-sha1 = "ebcd6e22d69f21249b7b8668351ebf42d6dc87a1"
@@ -33,9 +33,9 @@ uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[BlockArrays]]
 deps = ["ArrayLayouts", "FillArrays", "LinearAlgebra"]
-git-tree-sha1 = "a37151e369c618aebaff8b95b9db2f603246e160"
+git-tree-sha1 = "5524e27323cf4c4505699c3fb008c3f772269945"
 uuid = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
-version = "0.15.3"
+version = "0.16.9"
 
 [[ChainRulesCore]]
 deps = ["Compat", "LinearAlgebra", "SparseArrays"]
@@ -67,10 +67,8 @@ uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
 version = "3.39.0"
 
 [[CompilerSupportLibraries_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "8e695f735fca77e9708e795eda62afdb869cbb70"
+deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
-version = "0.3.4+0"
 
 [[DataStructures]]
 deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
@@ -114,6 +112,10 @@ git-tree-sha1 = "a32185f5428d3986f47c2ab78b1f216d5e6cc96f"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 version = "0.8.5"
 
+[[Downloads]]
+deps = ["ArgTools", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+
 [[FastGaussQuadrature]]
 deps = ["LinearAlgebra", "SpecialFunctions", "StaticArrays"]
 git-tree-sha1 = "5829b25887e53fb6730a9df2ff89ed24baa6abf6"
@@ -127,10 +129,10 @@ uuid = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 version = "1.11.1"
 
 [[FillArrays]]
-deps = ["LinearAlgebra", "Random", "SparseArrays"]
-git-tree-sha1 = "693210145367e7685d8604aee33d9bfb85db8b31"
+deps = ["LinearAlgebra", "Random", "SparseArrays", "Statistics"]
+git-tree-sha1 = "8756f9935b7ccc9064c6eef0bff0ad643df733a3"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "0.11.9"
+version = "0.12.7"
 
 [[FiniteDiff]]
 deps = ["ArrayInterface", "LinearAlgebra", "Requires", "SparseArrays", "StaticArrays"]
@@ -147,7 +149,7 @@ version = "0.10.21"
 [[Gridap]]
 deps = ["AbstractTrees", "BSON", "BlockArrays", "Combinatorics", "DocStringExtensions", "FastGaussQuadrature", "FileIO", "FillArrays", "ForwardDiff", "JLD2", "JSON", "LineSearches", "LinearAlgebra", "NLsolve", "NearestNeighbors", "QuadGK", "Random", "SparseArrays", "SparseMatricesCSR", "StaticArrays", "Test", "WriteVTK"]
 git-tree-sha1 = "1c5c6b7cbdc5895f690d731e3653d01636eaa243"
-repo-rev = "adding_symbolic_loop_vector"
+repo-rev = "gridap_distributed"
 repo-url = "https://github.com/gridap/Gridap.jl"
 uuid = "56d4f2e9-7ea1-5844-9cf6-b9c51ca7ce8e"
 version = "0.17.0"
@@ -196,18 +198,30 @@ git-tree-sha1 = "8076680b162ada2a031f707ac7b4953e30667a37"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 version = "0.21.2"
 
+[[LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+
+[[LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+
 [[LibGit2]]
-deps = ["Printf"]
+deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
 
 [[Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
 [[Libiconv_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "cba7b560fcc00f8cd770fa85a498cbc1d63ff618"
+git-tree-sha1 = "42b62845d70a619f063a7da093d995ec8e15e778"
 uuid = "94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
-version = "1.16.0+8"
+version = "1.16.1+1"
 
 [[LightXML]]
 deps = ["Libdl", "XML2_jll"]
@@ -241,10 +255,10 @@ uuid = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 version = "0.19.1"
 
 [[MPICH_jll]]
-deps = ["CompilerSupportLibraries_jll", "Libdl", "Pkg"]
-git-tree-sha1 = "4d37f1e07b4e2a74462eebf9ee48c626d15ffdac"
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "c6cafe3f9747c0a0740611e2dffc4d37248fb691"
 uuid = "7cb0a576-ebde-5e09-9194-50597f1243b4"
-version = "3.3.2+10"
+version = "3.4.2+0"
 
 [[MacroTools]]
 deps = ["Markdown", "Random"]
@@ -256,6 +270,10 @@ version = "0.5.8"
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
+[[MbedTLS_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+
 [[MicrosoftMPI_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
 git-tree-sha1 = "e5c90234b3967684c9c6f87b4a54549b4ce21836"
@@ -264,6 +282,9 @@ version = "10.1.3+0"
 
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
 
 [[NLSolversBase]]
 deps = ["DiffResults", "Distributed", "FiniteDiff", "ForwardDiff"]
@@ -288,23 +309,24 @@ git-tree-sha1 = "16baacfdc8758bc374882566c9187e785e85c2f0"
 uuid = "b8a86587-4115-5ab1-83bc-aa920d37bbce"
 version = "0.4.9"
 
+[[NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+
 [[OpenLibm_jll]]
-deps = ["Libdl", "Pkg"]
-git-tree-sha1 = "d22054f66695fe580009c09e765175cbf7f13031"
+deps = ["Artifacts", "Libdl"]
 uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
-version = "0.7.1+0"
 
 [[OpenMPI_jll]]
-deps = ["Libdl", "Pkg"]
-git-tree-sha1 = "41b983e26a7ab8c9bf05f7d70c274b817d541b46"
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "a784e5133fc7e204c900f2cf38ed37a92ff9248d"
 uuid = "fe0851c0-eecd-5654-98d4-656369965a5c"
-version = "4.0.2+2"
+version = "4.1.1+2"
 
 [[OpenSpecFun_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "9db77584158d0ab52307f8c04f8e7c08ca76b5b3"
+git-tree-sha1 = "13652491f6856acfd2db29360e1bbcd4565d04f1"
 uuid = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
-version = "0.5.3+4"
+version = "0.5.5+0"
 
 [[OrderedCollections]]
 git-tree-sha1 = "85f8e6578bf1f9ee0d11e7bb1b1456435479d47c"
@@ -332,7 +354,7 @@ uuid = "5a9dfac6-5c52-46f7-8278-5e2210713be9"
 version = "0.2.2"
 
 [[Pkg]]
-deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [[Preferences]]
@@ -352,7 +374,7 @@ uuid = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 version = "2.4.2"
 
 [[REPL]]
-deps = ["InteractiveUtils", "Markdown", "Sockets"]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[Random]]
@@ -394,9 +416,9 @@ uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [[SparseMatricesCSR]]
 deps = ["LinearAlgebra", "SparseArrays", "SuiteSparse"]
-git-tree-sha1 = "9d3f74b506eec1e92b384df19e9c50e7ab7cf2d4"
+git-tree-sha1 = "ad906b39ce5e05ec509495dfc7b38d11ce9ab40b"
 uuid = "a0a7dd2c-ebf4-11e9-1f05-cf50bc540ca1"
-version = "0.6.4"
+version = "0.6.5"
 
 [[SpecialFunctions]]
 deps = ["ChainRulesCore", "IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
@@ -431,12 +453,14 @@ uuid = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 
 [[TOML]]
 deps = ["Dates"]
-git-tree-sha1 = "44aaac2d2aec4a850302f9aa69127c74f0c3787e"
 uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
-version = "1.0.3"
+
+[[Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 
 [[Test]]
-deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [[TranscodingStreams]]
@@ -465,12 +489,18 @@ version = "1.11.0"
 
 [[XML2_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Libiconv_jll", "Pkg", "Zlib_jll"]
-git-tree-sha1 = "be0db24f70aae7e2b89f2f3092e93b8606d659a6"
+git-tree-sha1 = "1acf5bdf07aa0907e0a37d3718bb88d4b687b74a"
 uuid = "02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"
-version = "2.9.10+3"
+version = "2.9.12+0"
 
 [[Zlib_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "320228915c8debb12cb434c59057290f0834dbf6"
+deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
-version = "1.2.11+18"
+
+[[nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+
+[[p7zip_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -39,9 +39,9 @@ version = "0.15.3"
 
 [[ChainRulesCore]]
 deps = ["Compat", "LinearAlgebra", "SparseArrays"]
-git-tree-sha1 = "8d954297bc51cc64f15937c2093799c3617b73e4"
+git-tree-sha1 = "d9e40e3e370ee56c5b57e0db651d8f92bce98fea"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.10.0"
+version = "1.10.1"
 
 [[CodecZlib]]
 deps = ["TranscodingStreams", "Zlib_jll"]
@@ -146,8 +146,8 @@ version = "0.10.21"
 
 [[Gridap]]
 deps = ["AbstractTrees", "BSON", "BlockArrays", "Combinatorics", "DocStringExtensions", "FastGaussQuadrature", "FileIO", "FillArrays", "ForwardDiff", "JLD2", "JSON", "LineSearches", "LinearAlgebra", "NLsolve", "NearestNeighbors", "QuadGK", "Random", "SparseArrays", "SparseMatricesCSR", "StaticArrays", "Test", "WriteVTK"]
-git-tree-sha1 = "192cb4f55c2eeefcd7e39dd208a58e46fc9840a5"
-repo-rev = "gridap_distributed"
+git-tree-sha1 = "1c5c6b7cbdc5895f690d731e3653d01636eaa243"
+repo-rev = "adding_symbolic_loop_vector"
 repo-url = "https://github.com/gridap/Gridap.jl"
 uuid = "56d4f2e9-7ea1-5844-9cf6-b9c51ca7ce8e"
 version = "0.17.0"
@@ -160,6 +160,12 @@ version = "0.1.0"
 [[InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[InverseFunctions]]
+deps = ["Test"]
+git-tree-sha1 = "f0c6489b12d28fb4c2103073ec7452f3423bd308"
+uuid = "3587e190-3f89-42d0-90ee-14403ec27112"
+version = "0.1.1"
 
 [[IrrationalConstants]]
 git-tree-sha1 = "7fd44fd4ff43fc60815f8e764c0f352b83c49151"
@@ -220,10 +226,10 @@ deps = ["Libdl"]
 uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [[LogExpFunctions]]
-deps = ["ChainRulesCore", "DocStringExtensions", "IrrationalConstants", "LinearAlgebra"]
-git-tree-sha1 = "34dc30f868e368f8a17b728a1238f3fcda43931a"
+deps = ["ChainRulesCore", "DocStringExtensions", "InverseFunctions", "IrrationalConstants", "LinearAlgebra"]
+git-tree-sha1 = "6193c3815f13ba1b78a51ce391db8be016ae9214"
 uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
-version = "0.3.3"
+version = "0.3.4"
 
 [[Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -319,7 +325,7 @@ version = "2.0.6"
 
 [[PartitionedArrays]]
 deps = ["Distances", "IterativeSolvers", "LinearAlgebra", "MPI", "Printf", "SparseArrays", "SparseMatricesCSR"]
-git-tree-sha1 = "763146e768b343fec44c521f5c7822116adc24ad"
+git-tree-sha1 = "4b79fc86fd30f5063d97d9c40291976ede6fd4d5"
 repo-rev = "gridap_distributed"
 repo-url = "https://github.com/fverdugo/PartitionedArrays.jl.git"
 uuid = "5a9dfac6-5c52-46f7-8278-5e2210713be9"
@@ -388,9 +394,9 @@ uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [[SparseMatricesCSR]]
 deps = ["LinearAlgebra", "SparseArrays", "SuiteSparse"]
-git-tree-sha1 = "8706e36c81a0cd0e716297c830d4c3ebfa1ed770"
+git-tree-sha1 = "9d3f74b506eec1e92b384df19e9c50e7ab7cf2d4"
 uuid = "a0a7dd2c-ebf4-11e9-1f05-cf50bc540ca1"
-version = "0.6.3"
+version = "0.6.4"
 
 [[SpecialFunctions]]
 deps = ["ChainRulesCore", "IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -146,9 +146,9 @@ version = "0.10.21"
 
 [[Gridap]]
 deps = ["AbstractTrees", "BSON", "BlockArrays", "Combinatorics", "DocStringExtensions", "FastGaussQuadrature", "FileIO", "FillArrays", "ForwardDiff", "JLD2", "JSON", "LineSearches", "LinearAlgebra", "NLsolve", "NearestNeighbors", "QuadGK", "Random", "SparseArrays", "SparseMatricesCSR", "StaticArrays", "Test", "WriteVTK"]
-git-tree-sha1 = "0557dbbfabbc0ce45a5377c9be0b9058e4ef298d"
+git-tree-sha1 = "192cb4f55c2eeefcd7e39dd208a58e46fc9840a5"
 repo-rev = "gridap_distributed"
-repo-url = "https://github.com/gridap/Gridap.jl.git"
+repo-url = "https://github.com/gridap/Gridap.jl"
 uuid = "56d4f2e9-7ea1-5844-9cf6-b9c51ca7ce8e"
 version = "0.17.0"
 

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -319,8 +319,8 @@ version = "2.0.6"
 
 [[PartitionedArrays]]
 deps = ["IterativeSolvers", "LinearAlgebra", "MPI", "Printf", "SparseArrays", "SparseMatricesCSR"]
-git-tree-sha1 = "38a986dc7298d3d2a8e993c7db7944132c757415"
-repo-rev = "gridap_distributed"
+git-tree-sha1 = "4a25fbecc605305309f9c4bbcc4866a1670ccd75"
+repo-rev = "overloading_fill_psparsematrix"
 repo-url = "https://github.com/fverdugo/PartitionedArrays.jl.git"
 uuid = "5a9dfac6-5c52-46f7-8278-5e2210713be9"
 version = "0.2.2"

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -5,9 +5,6 @@ git-tree-sha1 = "03e0550477d86222521d254b741d470ba17ea0b5"
 uuid = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 version = "0.3.4"
 
-[[ArgTools]]
-uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
-
 [[ArrayInterface]]
 deps = ["Compat", "IfElse", "LinearAlgebra", "Requires", "SparseArrays", "Static"]
 git-tree-sha1 = "b8d49c34c3da35f220e7295659cd0bab8e739fed"
@@ -16,32 +13,35 @@ version = "3.1.33"
 
 [[ArrayLayouts]]
 deps = ["FillArrays", "LinearAlgebra", "SparseArrays"]
-git-tree-sha1 = "a745df3fdce8aff885e6f4a3b7427cc27ce5f86c"
+git-tree-sha1 = "623a32b87ef0b85d26320a8cc7e57ded707aef64"
 uuid = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
-version = "0.7.6"
+version = "0.7.5"
 
 [[Artifacts]]
+deps = ["Pkg"]
+git-tree-sha1 = "c30985d8821e0cd73870b17b0ed0ce6dc44cb744"
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+version = "1.3.0"
 
 [[BSON]]
-git-tree-sha1 = "92b8a8479128367aaab2620b8e73dff632f5ae69"
+git-tree-sha1 = "ebcd6e22d69f21249b7b8668351ebf42d6dc87a1"
 uuid = "fbb218c0-5317-5bc6-957e-2ee96dd4b1f0"
-version = "0.3.3"
+version = "0.3.4"
 
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[BlockArrays]]
 deps = ["ArrayLayouts", "FillArrays", "LinearAlgebra"]
-git-tree-sha1 = "782362509cf50a51092f513e92783c18ab0b6d51"
+git-tree-sha1 = "a37151e369c618aebaff8b95b9db2f603246e160"
 uuid = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
-version = "0.16.8"
+version = "0.15.3"
 
 [[ChainRulesCore]]
 deps = ["Compat", "LinearAlgebra", "SparseArrays"]
-git-tree-sha1 = "a325370b9dd0e6bf5656a6f1a7ae80755f8ccc46"
+git-tree-sha1 = "74e8234fb738c45e2af55fdbcd9bfbe00c2446fa"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.7.2"
+version = "1.8.0"
 
 [[CodecZlib]]
 deps = ["TranscodingStreams", "Zlib_jll"]
@@ -67,8 +67,10 @@ uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
 version = "3.39.0"
 
 [[CompilerSupportLibraries_jll]]
-deps = ["Artifacts", "Libdl"]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "8e695f735fca77e9708e795eda62afdb869cbb70"
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+version = "0.3.4+0"
 
 [[DataStructures]]
 deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
@@ -112,10 +114,6 @@ git-tree-sha1 = "a32185f5428d3986f47c2ab78b1f216d5e6cc96f"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 version = "0.8.5"
 
-[[Downloads]]
-deps = ["ArgTools", "LibCURL", "NetworkOptions"]
-uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
-
 [[FastGaussQuadrature]]
 deps = ["LinearAlgebra", "SpecialFunctions", "StaticArrays"]
 git-tree-sha1 = "5829b25887e53fb6730a9df2ff89ed24baa6abf6"
@@ -129,10 +127,10 @@ uuid = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 version = "1.11.1"
 
 [[FillArrays]]
-deps = ["LinearAlgebra", "Random", "SparseArrays", "Statistics"]
-git-tree-sha1 = "29890dfbc427afa59598b8cfcc10034719bd7744"
+deps = ["LinearAlgebra", "Random", "SparseArrays"]
+git-tree-sha1 = "693210145367e7685d8604aee33d9bfb85db8b31"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "0.12.6"
+version = "0.11.9"
 
 [[FiniteDiff]]
 deps = ["ArrayInterface", "LinearAlgebra", "Requires", "SparseArrays", "StaticArrays"]
@@ -164,9 +162,9 @@ deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[IrrationalConstants]]
-git-tree-sha1 = "f76424439413893a832026ca355fe273e93bce94"
+git-tree-sha1 = "7fd44fd4ff43fc60815f8e764c0f352b83c49151"
 uuid = "92d709cd-6900-40b7-9082-c6be49f344b6"
-version = "0.1.0"
+version = "0.1.1"
 
 [[IterativeSolvers]]
 deps = ["LinearAlgebra", "Printf", "Random", "RecipesBase", "SparseArrays"]
@@ -176,9 +174,9 @@ version = "0.9.1"
 
 [[JLD2]]
 deps = ["DataStructures", "FileIO", "MacroTools", "Mmap", "Pkg", "Printf", "Reexport", "TranscodingStreams", "UUIDs"]
-git-tree-sha1 = "192934b3e2a94e897ce177423fd6cf7bdf464bce"
+git-tree-sha1 = "46b7834ec8165c541b0b5d1c8ba63ec940723ffb"
 uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
-version = "0.4.14"
+version = "0.4.15"
 
 [[JLLWrappers]]
 deps = ["Preferences"]
@@ -192,30 +190,18 @@ git-tree-sha1 = "8076680b162ada2a031f707ac7b4953e30667a37"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 version = "0.21.2"
 
-[[LibCURL]]
-deps = ["LibCURL_jll", "MozillaCACerts_jll"]
-uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
-
-[[LibCURL_jll]]
-deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
-uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
-
 [[LibGit2]]
-deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
+deps = ["Printf"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
-
-[[LibSSH2_jll]]
-deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
-uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
 
 [[Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
 [[Libiconv_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "42b62845d70a619f063a7da093d995ec8e15e778"
+git-tree-sha1 = "cba7b560fcc00f8cd770fa85a498cbc1d63ff618"
 uuid = "94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
-version = "1.16.1+1"
+version = "1.16.0+8"
 
 [[LightXML]]
 deps = ["Libdl", "XML2_jll"]
@@ -249,10 +235,10 @@ uuid = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 version = "0.19.0"
 
 [[MPICH_jll]]
-deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "c6cafe3f9747c0a0740611e2dffc4d37248fb691"
+deps = ["CompilerSupportLibraries_jll", "Libdl", "Pkg"]
+git-tree-sha1 = "4d37f1e07b4e2a74462eebf9ee48c626d15ffdac"
 uuid = "7cb0a576-ebde-5e09-9194-50597f1243b4"
-version = "3.4.2+0"
+version = "3.3.2+10"
 
 [[MacroTools]]
 deps = ["Markdown", "Random"]
@@ -264,10 +250,6 @@ version = "0.5.8"
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
-[[MbedTLS_jll]]
-deps = ["Artifacts", "Libdl"]
-uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-
 [[MicrosoftMPI_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
 git-tree-sha1 = "e5c90234b3967684c9c6f87b4a54549b4ce21836"
@@ -276,9 +258,6 @@ version = "10.1.3+0"
 
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
-
-[[MozillaCACerts_jll]]
-uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
 
 [[NLSolversBase]]
 deps = ["DiffResults", "Distributed", "FiniteDiff", "ForwardDiff"]
@@ -303,24 +282,23 @@ git-tree-sha1 = "16baacfdc8758bc374882566c9187e785e85c2f0"
 uuid = "b8a86587-4115-5ab1-83bc-aa920d37bbce"
 version = "0.4.9"
 
-[[NetworkOptions]]
-uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
-
 [[OpenLibm_jll]]
-deps = ["Artifacts", "Libdl"]
+deps = ["Libdl", "Pkg"]
+git-tree-sha1 = "d22054f66695fe580009c09e765175cbf7f13031"
 uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
+version = "0.7.1+0"
 
 [[OpenMPI_jll]]
-deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "a784e5133fc7e204c900f2cf38ed37a92ff9248d"
+deps = ["Libdl", "Pkg"]
+git-tree-sha1 = "41b983e26a7ab8c9bf05f7d70c274b817d541b46"
 uuid = "fe0851c0-eecd-5654-98d4-656369965a5c"
-version = "4.1.1+2"
+version = "4.0.2+2"
 
 [[OpenSpecFun_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "13652491f6856acfd2db29360e1bbcd4565d04f1"
+git-tree-sha1 = "9db77584158d0ab52307f8c04f8e7c08ca76b5b3"
 uuid = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
-version = "0.5.5+0"
+version = "0.5.3+4"
 
 [[OrderedCollections]]
 git-tree-sha1 = "85f8e6578bf1f9ee0d11e7bb1b1456435479d47c"
@@ -348,7 +326,7 @@ uuid = "5a9dfac6-5c52-46f7-8278-5e2210713be9"
 version = "0.2.2"
 
 [[Pkg]]
-deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [[Preferences]]
@@ -368,7 +346,7 @@ uuid = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 version = "2.4.2"
 
 [[REPL]]
-deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
+deps = ["InteractiveUtils", "Markdown", "Sockets"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[Random]]
@@ -409,10 +387,10 @@ deps = ["LinearAlgebra", "Random"]
 uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [[SparseMatricesCSR]]
-deps = ["LinearAlgebra", "SparseArrays"]
-git-tree-sha1 = "dd6dda1484d4031a47d27614ceeb89f511cd9ca4"
+deps = ["LinearAlgebra", "SparseArrays", "SuiteSparse"]
+git-tree-sha1 = "8706e36c81a0cd0e716297c830d4c3ebfa1ed770"
 uuid = "a0a7dd2c-ebf4-11e9-1f05-cf50bc540ca1"
-version = "0.6.1"
+version = "0.6.3"
 
 [[SpecialFunctions]]
 deps = ["ChainRulesCore", "IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
@@ -441,16 +419,18 @@ git-tree-sha1 = "1958272568dc176a1d881acb797beb909c785510"
 uuid = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
 version = "1.0.0"
 
+[[SuiteSparse]]
+deps = ["Libdl", "LinearAlgebra", "Serialization", "SparseArrays"]
+uuid = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
+
 [[TOML]]
 deps = ["Dates"]
+git-tree-sha1 = "44aaac2d2aec4a850302f9aa69127c74f0c3787e"
 uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
-
-[[Tar]]
-deps = ["ArgTools", "SHA"]
-uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+version = "1.0.3"
 
 [[Test]]
-deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
+deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [[TranscodingStreams]]
@@ -479,18 +459,12 @@ version = "1.11.0"
 
 [[XML2_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Libiconv_jll", "Pkg", "Zlib_jll"]
-git-tree-sha1 = "1acf5bdf07aa0907e0a37d3718bb88d4b687b74a"
+git-tree-sha1 = "be0db24f70aae7e2b89f2f3092e93b8606d659a6"
 uuid = "02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"
-version = "2.9.12+0"
+version = "2.9.10+3"
 
 [[Zlib_jll]]
-deps = ["Libdl"]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "320228915c8debb12cb434c59057290f0834dbf6"
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
-
-[[nghttp2_jll]]
-deps = ["Artifacts", "Libdl"]
-uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
-
-[[p7zip_jll]]
-deps = ["Artifacts", "Libdl"]
-uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
+version = "1.2.11+18"

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -39,9 +39,9 @@ version = "0.15.3"
 
 [[ChainRulesCore]]
 deps = ["Compat", "LinearAlgebra", "SparseArrays"]
-git-tree-sha1 = "2f294fae04aa5069a67964a3366e151e09ea7c09"
+git-tree-sha1 = "8d954297bc51cc64f15937c2093799c3617b73e4"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.9.0"
+version = "1.10.0"
 
 [[CodecZlib]]
 deps = ["TranscodingStreams", "Zlib_jll"]
@@ -146,7 +146,7 @@ version = "0.10.21"
 
 [[Gridap]]
 deps = ["AbstractTrees", "BSON", "BlockArrays", "Combinatorics", "DocStringExtensions", "FastGaussQuadrature", "FileIO", "FillArrays", "ForwardDiff", "JLD2", "JSON", "LineSearches", "LinearAlgebra", "NLsolve", "NearestNeighbors", "QuadGK", "Random", "SparseArrays", "SparseMatricesCSR", "StaticArrays", "Test", "WriteVTK"]
-git-tree-sha1 = "c58a6aade499e243bddc152f6acdc17d45886a94"
+git-tree-sha1 = "0557dbbfabbc0ce45a5377c9be0b9058e4ef298d"
 repo-rev = "gridap_distributed"
 repo-url = "https://github.com/gridap/Gridap.jl.git"
 uuid = "56d4f2e9-7ea1-5844-9cf6-b9c51ca7ce8e"
@@ -394,9 +394,9 @@ version = "0.6.3"
 
 [[SpecialFunctions]]
 deps = ["ChainRulesCore", "IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
-git-tree-sha1 = "793793f1df98e3d7d554b65a107e9c9a6399a6ed"
+git-tree-sha1 = "2d57e14cd614083f132b6224874296287bfa3979"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
-version = "1.7.0"
+version = "1.8.0"
 
 [[Static]]
 deps = ["IfElse"]

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,6 @@ PartitionedArrays = "5a9dfac6-5c52-46f7-8278-5e2210713be9"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-Gridap = "0.17"
 PartitionedArrays = "0.2"
 julia = "1.3"
 

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,6 @@ PartitionedArrays = "5a9dfac6-5c52-46f7-8278-5e2210713be9"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-PartitionedArrays = "0.2"
 julia = "1.3"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ PartitionedArrays = "5a9dfac6-5c52-46f7-8278-5e2210713be9"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
+Gridap = "0.17"
 julia = "1.3"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,10 @@ PartitionedArrays = "5a9dfac6-5c52-46f7-8278-5e2210713be9"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
+FillArrays = "0.8.4, 0.9, 0.10, 0.11, 0.12"
 Gridap = "0.17"
+MPI = "0.16, 0.17, 0.18, 0.19"
+PartitionedArrays = "0.2"
 julia = "1.3"
 
 [extras]

--- a/src/Algebra.jl
+++ b/src/Algebra.jl
@@ -547,8 +547,18 @@ function Algebra.create_from_nz(a::PVectorAllocationSubAssembledRows)
 
    # Find the ghost rows
    hrow_to_hrdof=map_parts(a.counters,rdofs.partition) do counter, indices
-    hlids_touched=findall(counter.touched)
-    oh_lid=-indices.lid_to_ohid[hlids_touched]
+    lids_touched=findall(counter.touched)
+    nhlids = count((x)->indices.lid_to_ohid[x]<0,lids_touched)
+    hlids = Vector{Int32}(undef,nhlids)
+    cur=1
+    for lid in lids_touched
+      hlid=indices.lid_to_ohid[lid]
+      if hlid<0
+        hlids[cur]=-hlid
+        cur=cur+1
+      end
+    end
+    hlids
    end
    hrow_to_gid, hrow_to_part = map_parts(
        find_gid_and_part,hrow_to_hrdof,rdofs.partition)

--- a/src/Algebra.jl
+++ b/src/Algebra.jl
@@ -613,33 +613,3 @@ function Algebra.create_from_nz(a::PVectorAllocationTrackTouchedAndValues)
    end
    b
 end
-
-function Gridap.FESpaces.symbolic_loop_vector!(b,a::GenericSparseMatrixAssembler,vecdata)
-  get_vec(a::Tuple) = a[1]
-  get_vec(a) = a
-  if Gridap.Algebra.LoopStyle(b) == Gridap.Algebra.DoNotLoop()
-    return b
-  end
-  for (cellvec,_cellids) in zip(vecdata...)
-    cellids = Gridap.FESpaces.map_cell_rows(a.strategy,_cellids)
-    rows_cache = array_cache(cellids)
-    if length(cellids) > 0
-      vec1 = get_vec(first(cellvec))
-      rows1 = getindex!(rows_cache,cellids,1)
-      touch! = TouchEntriesMap()
-      touch_cache = return_cache(touch!,b,vec1,rows1)
-      caches = touch_cache, rows_cache
-      _symbolic_loop_vector!(b,caches,cellids,vec1)
-    end
-  end
-  b
-end
-
-@noinline function _symbolic_loop_vector!(A,caches,cellids,vec1)
-  touch_cache, rows_cache = caches
-  touch! = TouchEntriesMap()
-  for cell in 1:length(cellids)
-    rows = getindex!(rows_cache,cellids,cell)
-    evaluate!(touch_cache,touch!,A,vec1,rows)
-  end
-end

--- a/src/Algebra.jl
+++ b/src/Algebra.jl
@@ -560,11 +560,6 @@ function local_views(a::PVectorAllocationTrackTouchedAndValues)
   a.allocations
 end
 
-function local_views(a::PVectorAllocationTrackTouchedAndValues,rows)
-  @assert a.rows === rows
-  a.allocations
-end
-
 function Algebra.create_from_nz(a::PVectorAllocationTrackTouchedAndValues)
    parts = get_part_ids(a.values)
    rdofs = a.rows # dof ids of the test space

--- a/src/Algebra.jl
+++ b/src/Algebra.jl
@@ -45,6 +45,16 @@ function Algebra.allocate_vector(::Type{<:PVector{T,A}},ids::PRange) where {T,A}
   PVector(values,ids)
 end
 
+function Algebra.fill_entries!(a::PVector,v::Number)
+  fill!(a,v)
+  a
+end
+
+function Algebra.fill_entries!(a::PSparseMatrix,v::Number)
+  fill!(a,v)
+  a
+end
+
 function local_views(a::PSparseMatrix)
   a.values
 end

--- a/src/Algebra.jl
+++ b/src/Algebra.jl
@@ -502,7 +502,7 @@ Gridap.Algebra.LoopStyle(::Type{<:ArrayAllocationTrackTouchedAndValues}) = Grida
 
 function local_views(a::PVectorAllocationTrackTouchedAndValues,rows)
   @check rows === a.rows
-  a.values
+  a.allocations
 end
 
 @inline function Arrays.add_entry!(c::Function,a::ArrayAllocationTrackTouchedAndValues,v,i,j)

--- a/src/FESpaces.jl
+++ b/src/FESpaces.jl
@@ -441,25 +441,3 @@ function FESpaces.SparseMatrixAssembler(
   cols = get_free_dof_ids(trial)
   DistributedSparseMatrixAssembler(par_strategy,assems,matrix_builder,vector_builder,rows,cols)
 end
-
-################### Experimental (required for assemble_vector + SubAssembledRows)
-
-function Gridap.FESpaces.assemble_vector(
-  a::DistributedSparseMatrixAssembler{<:SubAssembledRows},vecdata)
-
-  matrix_builder = a.matrix_builder
-  vector_builder = PVectorBuilderSubAssembledRows(a.vector_builder.local_vector_type)
-  as=DistributedSparseMatrixAssembler(a.strategy,
-                                      a.assems,
-                                      matrix_builder,
-                                      vector_builder,
-                                      a.rows,
-                                      a.cols)
-
-  v1 = nz_counter(get_vector_builder(as),(get_rows(as),))
-  symbolic_loop_vector!(v1,as,vecdata)
-  v2 = nz_allocation(v1)
-  numeric_loop_vector!(v2,as,vecdata)
-  v3 = create_from_nz(v2)
-  v3
-end

--- a/src/Geometry.jl
+++ b/src/Geometry.jl
@@ -101,7 +101,7 @@ function Geometry.CartesianDiscreteModel(
   nc = desc.partition
   msg = """
   A CartesianDiscreteModel needs a Cartesian subdomain partition
-  of the rigth dimensions.
+  of the right dimensions.
   """
   @assert length(size(parts)) == length(nc) msg
   gcids = PCartesianIndices(parts,nc,PArrays.with_ghost)
@@ -225,7 +225,7 @@ end
 # For the moment remove_ghost_cells
 # refers to the triangulation faces
 # pointing into the ghost cells
-# in the underlying background discrete 
+# in the underlying background discrete
 # model. This might change when solving
 # multi-field PDEs with one of the fields
 # defined on the boundary (e.g. a Lagrange multiplier)

--- a/test/FESpacesTests.jl
+++ b/test/FESpacesTests.jl
@@ -93,6 +93,14 @@ function main(parts)
   b=assemble_vector(assem,vecdata)
   @test sum(b)-1.0 < 1.0e-12
 
+  Ω = Triangulation(no_ghost,model)
+  dΩ = Measure(Ω,3)
+  l=∫(1*dv)dΩ
+  vecdata=collect_cell_vector(V,l)
+  assem = SparseMatrixAssembler(U,V,FullyAssembledRows())
+  b=assemble_vector(assem,vecdata)
+  @test sum(b)-1.0 < 1.0e-12
+
 end
 
 end # module

--- a/test/FESpacesTests.jl
+++ b/test/FESpacesTests.jl
@@ -11,7 +11,7 @@ function main(parts)
 
   output = mkpath(joinpath(@__DIR__,"output"))
 
-  domain = (0,4,0,4)
+  domain = (0,1,0,1)
   cells = (4,4)
   model = CartesianDiscreteModel(parts,domain,cells)
   Ω = Triangulation(model)
@@ -83,6 +83,15 @@ function main(parts)
   uh = solve(solver,op)
   eh = u - uh
   @test sqrt(sum(∫( abs2(eh) )dΩ)) < 1.0e-9
+
+  dv = get_fe_basis(V)
+  Ω = Triangulation(model)
+  dΩ = Measure(Ω,3)
+  l=∫(1*dv)dΩ
+  vecdata=collect_cell_vector(V,l)
+  assem = SparseMatrixAssembler(U,V,SubAssembledRows())
+  b=assemble_vector(assem,vecdata)
+  @test sum(b)-1.0 < 1.0e-12
 
 end
 

--- a/test/FESpacesTests.jl
+++ b/test/FESpacesTests.jl
@@ -44,12 +44,12 @@ function test_fe_spaces(parts,das)
   assem = SparseMatrixAssembler(U,V,das)
 
   data = collect_cell_matrix_and_vector(U,V,a(du,dv),l(dv),zh)
-  A,b = assemble_matrix_and_vector(assem,data)
-  x = A\b
-  r = A*x -b
-  uh = FEFunction(U,x)
-  eh = u - uh
-  @test sqrt(sum(∫( abs2(eh) )dΩint)) < 1.0e-9
+  A1,b1 = assemble_matrix_and_vector(assem,data)
+  x1 = A1\b1
+  r1 = A1*x1 -b1
+  uh1 = FEFunction(U,x1)
+  eh1 = u - uh1
+  @test sqrt(sum(∫( abs2(eh1) )dΩint)) < 1.0e-9
 
   writevtk(Ω,joinpath(output,"Ω"), nsubcells=10,
     celldata=["err"=>cont[Ωint]],
@@ -57,14 +57,13 @@ function test_fe_spaces(parts,das)
 
   writevtk(Γ,joinpath(output,"Γ"),cellfields=["uh"=>uh])
 
-  data = collect_cell_matrix_and_vector(U,V,a(du,dv),l(dv),zh)
-  A,b = allocate_matrix_and_vector(assem,data)
-  assemble_matrix_and_vector!(A,b,assem,data)
-  x = A\b
-  r = A*x -b
-  uh = FEFunction(U,x)
-  eh = u - uh
-  sqrt(sum(∫( abs2(eh) )dΩint)) < 1.0e-9
+  A2,b2 = allocate_matrix_and_vector(assem,data)
+  assemble_matrix_and_vector!(A2,b2,assem,data)
+  x2 = A2\b2
+  r2 = A2*x2 -b2
+  uh = FEFunction(U,x2)
+  eh2 = u - uh
+  sqrt(sum(∫( abs2(eh2) )dΩint)) < 1.0e-9
 
   op = AffineFEOperator(a,l,U,V,das)
   solver = LinearFESolver(BackslashSolver())
@@ -98,17 +97,17 @@ function test_fe_spaces(parts,das)
   l=∫(1*dv)dΩass
   vecdata=collect_cell_vector(V,l)
   assem = SparseMatrixAssembler(U,V,das)
-  b=assemble_vector(assem,vecdata)
-  @test abs(sum(b)-length(b)) < 1.0e-12
+  b1=assemble_vector(assem,vecdata)
+  @test abs(sum(b1)-length(b1)) < 1.0e-12
 
-  b=allocate_vector(assem,vecdata)
-  assemble_vector!(b,assem,vecdata)
-  @test abs(sum(b)-1.0) < 1.0e-12
+  b2=allocate_vector(assem,vecdata)
+  assemble_vector!(b2,assem,vecdata)
+  @test abs(sum(b2)-length(b2)) < 1.0e-12
 
 end
 
 function main(parts)
-  #test_fe_spaces(parts,SubAssembledRows())
+  test_fe_spaces(parts,SubAssembledRows())
   test_fe_spaces(parts,FullyAssembledRows())
 end
 

--- a/test/FESpacesTests.jl
+++ b/test/FESpacesTests.jl
@@ -72,10 +72,18 @@ function test_fe_spaces(parts,das)
   @test sqrt(sum(∫( abs2(eh) )dΩint)) < 1.0e-9
 
   data = collect_cell_matrix(U,V,a(du,dv))
-  A2 = assemble_matrix(assem,data)
+  A3 = assemble_matrix(assem,data)
+  x3 = A3\op.op.vector
+  uh = FEFunction(U,x3)
+  eh3 = u - uh
+  sqrt(sum(∫( abs2(eh3) )dΩint)) < 1.0e-9
 
-  A2 = allocate_matrix(assem,data)
-  assemble_matrix!(A2,assem,data)
+  A4 = allocate_matrix(assem,data)
+  assemble_matrix!(A4,assem,data)
+  x4 = A4\op.op.vector
+  uh = FEFunction(U,x4)
+  eh4 = u - uh
+  sqrt(sum(∫( abs2(eh4) )dΩint)) < 1.0e-9
 
   al(u,v) = ∫( ∇(v)⋅∇(u) )dΩass
   ll(v) = ∫( 0*v )dΩass


### PR DESCRIPTION
Hi @fverdugo, 

In this PR, I came up with an aproach to implement the rhs assembly for `SubAssembledRows()`, which is the complicated case. Let us decide if this is the way to go, possible improvements, etc.. The PR also solves the rhs assembly for the  `FullyAssembledRows()` strategy, although I would say there is not much to discuss here, this strategy is trivial.

The main difficulty comes from the fact that `SubAssembledRows()` requires the `lid`s of the ghost dofs which are touched during the assembly loop over owned cells. In the `matrix_and_vector_assemble` case, we are somehow cheating, because this information comes from the matrix assembly process, namely in the row identifiers array `I`.  The `PvectorBuilder`/`PVectorCounter`/`PVectorAllocation` set of assemble interface implementations alone do not seem to serve the purpose of providing this information (see [here](https://github.com/gridap/GridapDistributed.jl/blob/f8e383da956764f2adfa683e9d5b128d05c2d9eb/src/Algebra.jl#L370)).

What I did to overcome this limitation is (perhaps there are other cleaner options within the current software design constraints, I am open to reconsideration):
1. I implemented a symbolic assembly loop to track the ghost dofs touched from owned cells. This required me to overwrite the current implementation of the symbolic assemly loop in Gridap.  See [here](https://github.com/gridap/GridapDistributed.jl/blob/f8e383da956764f2adfa683e9d5b128d05c2d9eb/src/Algebra.jl#L509). If we agree this is the way to go, this code should be moved to Gridap.
2. The symbolic assembly loop is leveraged with a new set of types to implement the assemble interface abstractions. Namely, the `ArrayCounterSubAssembledRows{T,A}` type for the Gridap assembler, and the counterparts of the `PvectorBuilder`/`PVectorCounter`/`PVectorAllocation` types for the GridapDistributed assembler.
3. In order to leverage the data types implemented in 2., I had to intercept (overrride) the `assemble_vector` function in Gridap for the particular case in which we have the `SubAssembledRows` strategy. Besides, I cannot leverage the input `DistributedAssembler` for the symbolic stage, as it was by default initialized with the  `PvectorBuilder` type, which does not serve the purpose. As a result, I have to create an-hoc `DistributedAssembler` for the symbolic stage.This is arguibly the most controversial part of the PR.  See [here](https://github.com/gridap/GridapDistributed.jl/blob/ce94cf5f1a9da6a1c39e6368413ab0169373f9bc/src/FESpaces.jl#L447). 

I am far from 100% sure, but I have the impression that having the `MatrixBuilder`, `VectorBuilder`, and `AssemblyStrategy` instances tighted to the `Assembler`, and a unique `Assembler` in the program is somehow jeopardizing the flexibility of the current sofware design. To be general, one might want to select different assembly strategies to assemble the vector in  `assemble_matrix_vector` and `assemble_vector`.  Does it make sense to have `SparseMatrixAssembler` and `ArrayAssembler` separately? Anyway this is not the only issue in this particular scenario, as I needed to use different assembly strategies in the symbolic and numerical loop. 


 





 

 

