### PR TITLE
Added a test_broken to test/sequential/runtests.jl

### DIFF
--- a/test/sequential/runtests.jl
+++ b/test/sequential/runtests.jl
@@ -1,6 +1,8 @@
 module SequentialTests
 
 using Test
+using PartitionedArrays
+using Gridap
 
 @time @testset "Geometry" begin include("GeometryTests.jl") end
 
@@ -13,5 +15,16 @@ using Test
 @time @testset "Poisson" begin include("PoissonTests.jl") end
 
 @time @testset "PLaplacian" begin include("PLaplacianTests.jl") end
+
+parts = get_part_ids(sequential,(1,1))
+ids   = PRange(parts,6)
+vec   = PVector(1.0,ids);
+ids2  = PRange(parts,12)
+vec2  = PVector(2.0,ids);
+vec3vals = map_parts(vec2.owned_values) do ov
+  Gridap.Arrays.SubVector(ov,1,6)
+end
+vec3  = PVector(vec3vals,ids);
+@test_broken vec .= vec .+ vec3
 
 end # module


### PR DESCRIPTION
Hi @fverdugo, 

in this PR I have added a new test_broken to `test/sequential/runtests.jl`. I added them directly here as I literally not found a better place. Any ideas of where to place this?

The test simplifies/synthethizes the following real code that currently crashes when executed in distributed mode (in Gridap mode it does NOT crash):

```julia
using Gridap
using GridapDistributed
using PartitionedArrays

function main_par(parts)
  domain = (0,1,0,1)
  cells  = (2,2)
  model  = CartesianDiscreteModel(parts,domain,cells)
  f(model)
end

function main_seq()
  domain = (0,1,0,1)
  cells  = (2,2)
  model  = CartesianDiscreteModel(domain,cells)
  f(model)
end

function f(model)

  reffe_lgn = ReferenceFE(lagrangian, Float64, 1)
  Q = FESpace(model, reffe_lgn; conformity=:H1)
  P = TrialFESpace(Q)
  S = FESpace(model, reffe_lgn; conformity=:H1)
  R = TrialFESpace(S)

  Ω  = Triangulation(model)
  dΩ = Measure(Ω,2)

  Y = MultiFieldFESpace([Q,S])
  X = MultiFieldFESpace([P,R])

  a(u,v)= ∫(v*u)dΩ
  l(v)  = ∫(v*1.0)dΩ
  ph=solve(AffineFEOperator(a,l,P,Q))
  rh=solve(AffineFEOperator(a,l,R,S))

  A((p,r),(q,s))= ∫(q*p+s*r)dΩ
  L((q,s))  = ∫(q*1.0+s*1.0)dΩ
  xh=solve(AffineFEOperator(A,L,X,Y))

  phv=get_free_dof_values(ph)
  rhv=get_free_dof_values(rh)
  phb,rhb=xh
  phv .= phv .+ get_free_dof_values(phb)
  rhv .= rhv .+ get_free_dof_values(rhb)
  nothing
end

main_seq()
prun_debug(main_par,sequential,(1,1))

```

For completeness ... the error is 

```
ERROR: LoadError: ArgumentError: an array of type `Gridap.Arrays.SubVector` shares memory with another argument
and must make a preventative copy of itself in order to maintain consistent semantics,
but `copy(::Gridap.Arrays.SubVector{Float64, Vector{Float64}})` returns a new array of type `Vector{Float64}`.
To fix, implement:
    `Base.unaliascopy(A::Gridap.Arrays.SubVector)::typeof(A)`
Stacktrace:
  [1] _unaliascopy(A::Gridap.Arrays.SubVector{Float64, Vector{Float64}}, C::Vector{Float64})
    @ Base ./abstractarray.jl:1368
  [2] unaliascopy(A::Gridap.Arrays.SubVector{Float64, Vector{Float64}})
    @ Base ./abstractarray.jl:1366
  [3] unaliascopy(A::SubArray{Float64, 1, Gridap.Arrays.SubVector{Float64, Vector{Float64}}, Tuple{Vector{Int32}}, false})
    @ Base ./subarray.jl:105
  [4] unalias
    @ ./abstractarray.jl:1349 [inlined]
  [5] broadcast_unalias
    @ ./broadcast.jl:957 [inlined]
  [6] preprocess
    @ ./broadcast.jl:964 [inlined]
  [7] preprocess_args
    @ ./broadcast.jl:967 [inlined]
  [8] preprocess_args
    @ ./broadcast.jl:966 [inlined]
  [9] preprocess
    @ ./broadcast.jl:963 [inlined]
 [10] copyto!
    @ ./broadcast.jl:980 [inlined]
 [11] copyto!
    @ ./broadcast.jl:936 [inlined]
 [12] materialize!
    @ ./broadcast.jl:894 [inlined]
 [13] materialize!
    @ ./broadcast.jl:891 [inlined]
 [14] (::PartitionedArrays.var"#145#147")(dest::SubArray{Float64, 1, Vector{Float64}, Tuple{Vector{Int32}}, false}, 
                                          x::Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(+), 
                                          Tuple{SubArray{Float64, 1, Vector{Float64}, Tuple{Vector{Int32}}, false}, 
                                                SubArray{Float64, 1, Gridap.Arrays.SubVector{Float64, Vector{Float64}}, Tuple{Vector{Int32}}, false}}})
    @ PartitionedArrays ~/.julia/packages/PartitionedArrays/0zLYD/src/Interfaces.jl:1547
 [15] map_parts(::Function, ::MPIData{SubArray{Float64, 1, Vector{Float64}, Tuple{Vector{Int32}}, false}, 2}, ::Vararg{MPIData, N} where N)
    @ PartitionedArrays ~/.julia/packages/PartitionedArrays/0zLYD/src/MPIBackend.jl:97
 [16] materialize!(a::PVector{Float64, MPIData{Vector{Float64}, 2}, PRange{MPIData{IndexSet, 2}, Exchanger{MPIData{Vector{Int32}, 2}, MPIData{Table{Int32}, 2}}, Nothing}}, b::PartitionedArrays.DistributedBroadcasted{MPIData{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(+), Tuple{SubArray{Float64, 1, Vector{Float64}, Tuple{Vector{Int32}}, false}, SubArray{Float64, 1, Gridap.Arrays.SubVector{Float64, Vector{Float64}}, Tuple{Vector{Int32}}, false}}}, 2}, MPIData{Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{1}, Nothing, typeof(+), Tuple{SubArray{Float64, 1, Vector{Float64}, Tuple{Vector{Int32}}, false}, SubArray{Float64, 1, Gridap.Arrays.SubVector{Float64, Vector{Float64}}, Tuple{Vector{Int32}}, false}}}, 2}, PRange{MPIData{IndexSet, 2}, Exchanger{MPIData{Vector{Int32}, 2}, MPIData{Table{Int32}, 2}}, Nothing}})
    @ PartitionedArrays ~/.julia/packages/PartitionedArrays/0zLYD/src/Interfaces.jl:1546
 [17] f(model::GridapDistributed.DistributedDiscreteModel{2, 2, MPIData{CartesianDiscreteModel{2, Float64, typeof(identity)}, 2}, PRange{MPIData{IndexSet, 2}, Exchanger{MPIData{Vector{Int32}, 2}, MPIData{Table{Int32}, 2}}, MPIData{PartitionedArrays.CartesianGidToPart{2}, 2}}})
    @ Main ~/git-repos/GridapDistributed.jl/mwe.jl:52
 [18] main_par(parts::MPIData{Int64, 2})
    @ Main ~/git-repos/GridapDistributed.jl/mwe.jl:10
 [19] prun_debug(driver::typeof(main_par), b::MPIBackend, nparts::Tuple{Int64, Int64})
    @ PartitionedArrays ~/.julia/packages/PartitionedArrays/0zLYD/src/MPIBackend.jl:48
 [20] top-level scope
    @ ~/git-repos/GridapDistributed.jl/mwe.jl:59
 [21] include(fname::String)
    @ Base.MainInclude ./client.jl:444
 [22] top-level scope
    @ REPL[1]:1
in expression starting at /home/amartin/git-repos/GridapDistributed.jl/mwe.jl:59
```
 

