### PR TITLE
Incorrect global Dof numbering generation

### DIFF
--- a/joss_paper/paper.bib
+++ b/joss_paper/paper.bib
@@ -1,0 +1,59 @@
+@article{Pearson:2017,
+  	url = {http://adsabs.harvard.edu/abs/2017arXiv170304627P},
+  	Archiveprefix = {arXiv},
+  	Author = {{Pearson}, S. and {Price-Whelan}, A.~M. and {Johnston}, K.~V.},
+  	Eprint = {1703.04627},
+  	Journal = {ArXiv e-prints},
+  	Keywords = {Astrophysics - Astrophysics of Galaxies},
+  	Month = mar,
+  	Title = {{Gaps in Globular Cluster Streams: Pal 5 and the Galactic Bar}},
+  	Year = 2017
+}
+
+@book{Binney:2008,
+  	url = {http://adsabs.harvard.edu/abs/2008gady.book.....B},
+  	Author = {{Binney}, J. and {Tremaine}, S.},
+  	Booktitle = {Galactic Dynamics: Second Edition, by James Binney and Scott Tremaine.~ISBN 978-0-691-13026-2 (HB).~Published by Princeton University Press, Princeton, NJ USA, 2008.},
+  	Publisher = {Princeton University Press},
+  	Title = {{Galactic Dynamics: Second Edition}},
+  	Year = 2008
+}
+
+@article{gaia,
+    author = {{Gaia Collaboration}},
+    title = "{The Gaia mission}",
+    journal = {Astronomy and Astrophysics},
+    archivePrefix = "arXiv",
+    eprint = {1609.04153},
+    primaryClass = "astro-ph.IM",
+    keywords = {space vehicles: instruments, Galaxy: structure, astrometry, parallaxes, proper motions, telescopes},
+    year = 2016,
+    month = nov,
+    volume = 595,
+    doi = {10.1051/0004-6361/201629272},
+    url = {http://adsabs.harvard.edu/abs/2016A%26A...595A...1G},
+}
+
+@article{astropy,
+    author = {{Astropy Collaboration}},
+    title = "{Astropy: A community Python package for astronomy}",
+    journal = {Astronomy and Astrophysics},
+    archivePrefix = "arXiv",
+    eprint = {1307.6212},
+    primaryClass = "astro-ph.IM",
+    keywords = {methods: data analysis, methods: miscellaneous, virtual observatory tools},
+    year = 2013,
+    month = oct,
+    volume = 558,
+    doi = {10.1051/0004-6361/201322068},
+    url = {http://adsabs.harvard.edu/abs/2013A%26A...558A..33A}
+}
+
+@misc{fidgit,
+  author = {A. M. Smith and K. Thaney and M. Hahnel},
+  title = {Fidgit: An ungodly union of GitHub and Figshare},
+  year = {2020},
+  publisher = {GitHub},
+  journal = {GitHub repository},
+  url = {https://github.com/arfon/fidgit}
+}

--- a/joss_paper/paper.md
+++ b/joss_paper/paper.md
@@ -1,0 +1,111 @@
+---
+title: 'GridapDistributed: a parallel distributed Finite Element toolbox in Julia'
+tags:
+  - Julia 
+  - Partial Differential Equations 
+  - Finite Elements 
+  - Parallel Distributed Computing 
+authors:
+  - name: Santiago Badia
+    orcid: 0000-0003-2391-4086 
+    affiliation: "1, 2" 
+  - name: Alberto F. Martín^[corresponding author]
+    orcid: 0000-0001-5751-4561 
+    affiliation: "1" 
+  - name: Francesc Verdugo
+    orcid: 0000-0003-3667-443X
+    affiliation: "2" 
+affiliations:
+ - name: School of Mathematics, Monash University, Clayton, Victoria, 3800, Australia. 
+   index: 1
+ - name: Centre Internacional de Mètodes Numèrics en Enginyeria, Esteve Terrades 5, E-08860 Castelldefels, Spain.
+   index: 2
+date: XXX December 2021
+bibliography: paper.bib
+
+# Optional fields if submitting to a AAS journal too, see this blog post:
+# https://blog.joss.theoj.org/2018/12/a-new-collaboration-with-aas-publishing
+aas-doi: 10.3847/xxxxx <- update this with the DOI from AAS once you know it.
+aas-journal: Journal of Open Source Software <- The name of the AAS journal.
+---
+
+# Summary
+
+The forces on stars, galaxies, and dark matter under external gravitational
+fields lead to the dynamical evolution of structures in the universe. The orbits
+of these bodies are therefore key to understanding the formation, history, and
+future state of galaxies. The field of "galactic dynamics," which aims to model
+the gravitating components of galaxies to study their structure and evolution,
+is now well-established, commonly taught, and frequently used in astronomy.
+Aside from toy problems and demonstrations, the majority of problems require
+efficient numerical tools, many of which require the same base code (e.g., for
+performing numerical orbit integration).
+
+# Statement of need
+
+`Gala` is an Astropy-affiliated Python package for galactic dynamics. Python
+enables wrapping low-level languages (e.g., C) for speed without losing
+flexibility or ease-of-use in the user-interface. The API for `Gala` was
+designed to provide a class-based and user-friendly interface to fast (C or
+Cython-optimized) implementations of common operations such as gravitational
+potential and force evaluation, orbit integration, dynamical transformations,
+and chaos indicators for nonlinear dynamics. `Gala` also relies heavily on and
+interfaces well with the implementations of physical units and astronomical
+coordinate systems in the `Astropy` package [@astropy] (`astropy.units` and
+`astropy.coordinates`).
+
+`Gala` was designed to be used by both astronomical researchers and by
+students in courses on gravitational dynamics or astronomy. It has already been
+used in a number of scientific publications [@Pearson:2017] and has also been
+used in graduate courses on Galactic dynamics to, e.g., provide interactive
+visualizations of textbook material [@Binney:2008]. The combination of speed,
+design, and support for Astropy functionality in `Gala` will enable exciting
+scientific explorations of forthcoming data releases from the *Gaia* mission
+[@gaia] by students and experts alike.
+
+# Mathematics
+
+Single dollars ($) are required for inline mathematics e.g. $f(x) = e^{\pi/x}$
+
+Double dollars make self-standing equations:
+
+$$\Theta(x) = \left\{\begin{array}{l}
+0\textrm{ if } x < 0\cr
+1\textrm{ else}
+\end{array}\right.$$
+
+You can also use plain \LaTeX for equations
+\begin{equation}\label{eq:fourier}
+\hat f(\omega) = \int_{-\infty}^{\infty} f(x) e^{i\omega x} dx
+\end{equation}
+and refer to \autoref{eq:fourier} from text.
+
+# Citations
+
+Citations to entries in paper.bib should be in
+[rMarkdown](http://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html)
+format.
+
+If you want to cite a software repository URL (e.g. something on GitHub without a preferred
+citation) then you can do it with the example BibTeX entry below for @fidgit.
+
+For a quick reference, the following citation commands can be used:
+- `@author:2001`  ->  "Author et al. (2001)"
+- `[@author:2001]` -> "(Author et al., 2001)"
+- `[@author1:2001; @author2:2001]` -> "(Author1 et al., 2001; Author2 et al., 2002)"
+
+# Figures
+
+Figures can be included like this:
+![Caption for example figure.\label{fig:example}](figure.png)
+and referenced from text using \autoref{fig:example}.
+
+Figure sizes can be customized by adding an optional second parameter:
+![Caption for example figure.](figure.png){ width=20% }
+
+# Acknowledgements
+
+We acknowledge contributions from Brigitta Sipocz, Syrtis Major, and Semyeong
+Oh, and support from Kathryn Johnston during the genesis of this project.
+
+# References


### PR DESCRIPTION
Hi @fverdugo, 

I am pretty sure that the current algorithm for the generation of FE space global DoFs in a parallel distributed context is NOT correct (I am puzzled why it has worked in the vast majority of cases, possibly due to the fact the the bug is in the ghost cells). In particular, two sweeps of communication among nearest neighbours are required to have all correct global DoFs (including those which are solely on ghost cells), while the current algorithm only performs a single sweep. The figures below illustrate the situation 
![IMG20211209105433](https://user-images.githubusercontent.com/38347633/145312896-237a6cb8-6b87-4ffd-875d-a77939ce818f.jpg)
![IMG20211209105455](https://user-images.githubusercontent.com/38347633/145312914-08e557ac-5cca-43ff-a42f-f5ac44c700e0.jpg)
![IMG20211209105503](https://user-images.githubusercontent.com/38347633/145312930-093983ea-3d34-43b4-8221-8e8195acb5b3.jpg)


Besides, to have the full correct information about dof ownership, an extra comm sweep is needed for `ldof_to_part`.  What I did in this PR is to replicate  the algorithm that we had in GridapDistributed 0.1.0 (https://github.com/gridap/GridapDistributed.jl/blob/v0.1.0/src/DistributedFESpaces.jl#L107), which I am pretty sure it was correct. 