### PR TITLE
Extend evaluate function for multiple distributed fields

### DIFF
--- a/src/CellData.jl
+++ b/src/CellData.jl
@@ -81,6 +81,22 @@ function Arrays.evaluate!(
   DistributedCellField(fields)
 end
 
+function Arrays.evaluate!(
+  cache,k::Operation,a::DistributedCellField,b::DistributedCellField,c::DistributedCellField)
+  fields = map_parts(a.fields,b.fields,c.fields) do f,g,h
+    evaluate!(nothing,k,f,g,h)
+  end
+  DistributedCellField(fields)
+end
+
+function Arrays.evaluate!(
+  cache,k::Operation,a::DistributedCellField,b::DistributedCellField,c::DistributedCellField,d::DistributedCellField)
+  fields = map_parts(a.fields,b.fields,c.fields,d.fields) do f,g,h,j
+    evaluate!(nothing,k,f,g,h,j)
+  end
+  DistributedCellField(fields)
+end
+
 function Arrays.evaluate!(cache,k::Operation,a::DistributedCellField,b::Number)
   fields = map_parts(a.fields) do f
     evaluate!(nothing,k,f,b)


### PR DESCRIPTION
I got an error when passing more than 2 Distributed field to a function, so I extended it manually

foo∘(u::DistributedCellField,G::DistributedCellField,GG::DistributedCellField) 
foo∘(u::DistributedCellField,gg::DistributedCellField,G::DistributedCellField,GG::DistributedCellField) 

I am using this in my own code [here](https://github.com/carlodev/LidDriven/blob/2c64c2dd6007e2d7effe33799191ed646076cc33/VMS/LidDriven_VMS_parallel.jl#L211)