### PR TITLE
DistributedCellDofs and other extras

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.7] - 2022-10-07
+## Unreleased
 
 ### Added
 - Added `DistributedCellDof`, a distributed wrapper for `Gridap.CellDof`. This new wrapper acts on `DistributedCellField` in the same way `Gridap.CellDof` acts on `CellField`. Added `get_fe_dof_basis` function, which extracts a `DistributedCellDof` from a `DistributedFESpace`. Since PR [#97](https://github.com/gridap/GridapDistributed.jl/pull/97).

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.7] - 2022-10-07
+
+### Added
+- Added `DistributedCellDof`, a distributed wrapper for `Gridap.CellDof`. This new wrapper acts on `DistributedCellField` in the same way `Gridap.CellDof` acts on `CellField`. Since PR [#97](https://github.com/gridap/GridapDistributed.jl/pull/97).
+- Added `gather_free_and_dirichlet_values!`, `gather_free_values!` and `gather_dirichlet_values!` wrapper functions. Since PR [#97](https://github.com/gridap/GridapDistributed.jl/pull/97).
+
 ## [0.2.6] - 2022-06-07
 
 ### Added

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.7] - 2022-10-07
 
 ### Added
-- Added `DistributedCellDof`, a distributed wrapper for `Gridap.CellDof`. This new wrapper acts on `DistributedCellField` in the same way `Gridap.CellDof` acts on `CellField`. Since PR [#97](https://github.com/gridap/GridapDistributed.jl/pull/97).
+- Added `DistributedCellDof`, a distributed wrapper for `Gridap.CellDof`. This new wrapper acts on `DistributedCellField` in the same way `Gridap.CellDof` acts on `CellField`. Added `get_fe_dof_basis` function, which extracts a `DistributedCellDof` from a `DistributedFESpace`. Since PR [#97](https://github.com/gridap/GridapDistributed.jl/pull/97).
 - Added `gather_free_and_dirichlet_values!`, `gather_free_values!` and `gather_dirichlet_values!` wrapper functions. Since PR [#97](https://github.com/gridap/GridapDistributed.jl/pull/97).
 
 ## [0.2.6] - 2022-06-07

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added `DistributedCellDof`, a distributed wrapper for `Gridap.CellDof`. This new wrapper acts on `DistributedCellField` in the same way `Gridap.CellDof` acts on `CellField`. Added `get_fe_dof_basis` function, which extracts a `DistributedCellDof` from a `DistributedFESpace`. Since PR [#97](https://github.com/gridap/GridapDistributed.jl/pull/97).
-- Added `gather_free_and_dirichlet_values!`, `gather_free_values!` and `gather_dirichlet_values!` wrapper functions. Since PR [#97](https://github.com/gridap/GridapDistributed.jl/pull/97).
+- Added `gather_free_and_dirichlet_values!` and `gather_free_values!` wrapper functions. Since PR [#97](https://github.com/gridap/GridapDistributed.jl/pull/97).
 
 ## [0.2.6] - 2022-06-07
 

--- a/src/CellData.jl
+++ b/src/CellData.jl
@@ -324,13 +324,11 @@ CellData.mean(a::DistributedCellField) = DistributedCellField(map_parts(mean,a.f
 
 # DistributedCellDof
 
-struct DistributedCellDof{A,B} <: DistributedCellDatum
+struct DistributedCellDof{A} <: DistributedCellDatum
   dofs::A
-  metadata::B
-  function DistributedCellDof(dofs::AbstractPData{<:CellDof},metadata=nothing)
+  function DistributedCellDof(dofs::AbstractPData{<:CellDof})
       A = typeof(dofs)
-      B = typeof(metadata)
-      new{A,B}(dofs,metadata)
+      new{A}(dofs)
   end
 end
 

--- a/src/FESpaces.jl
+++ b/src/FESpaces.jl
@@ -41,6 +41,14 @@ function Base.zero(f::DistributedFESpace)
   FEFunction(f,free_values,isconsistent)
 end
 
+function FESpaces.gather_free_values!(free_vals,f::DistributedFESpace,cell_vals)
+  map_parts(gather_free_values!,local_views(free_vals), local_views(f), local_views(cell_vals))
+end
+
+function FESpaces.gather_free_and_dirichlet_values!(free_vals,dir_vals,f::DistributedFESpace,cell_vals)
+  map_parts(gather_free_and_dirichlet_values!,local_views(free_vals), local_views(dir_vals), local_views(f), local_views(cell_vals))
+end
+
 function dof_wise_to_cell_wise!(cell_wise_vector,dof_wise_vector,cell_to_ldofs,cell_prange)
   map_parts(cell_wise_vector,
           dof_wise_vector,
@@ -332,6 +340,11 @@ end
 function FESpaces.get_trial_fe_basis(f::DistributedSingleFieldFESpace)
   fields = map_parts(get_trial_fe_basis,f.spaces)
   DistributedCellField(fields)
+end
+
+function FESpaces.get_fe_dof_basis(f::DistributedSingleFieldFESpace)
+  dofs = map_parts(get_fe_dof_basis,local_views(f))
+  DistributedCellDof(dofs)
 end
 
 function FESpaces.TrialFESpace(f::DistributedSingleFieldFESpace)

--- a/src/FESpaces.jl
+++ b/src/FESpaces.jl
@@ -41,12 +41,16 @@ function Base.zero(f::DistributedFESpace)
   FEFunction(f,free_values,isconsistent)
 end
 
-function FESpaces.gather_free_values!(free_vals,f::DistributedFESpace,cell_vals)
-  map_parts(gather_free_values!,local_views(free_vals), local_views(f), local_views(cell_vals))
+function FESpaces.gather_free_values!(free_values,f::DistributedFESpace,cell_vals)
+  map_parts(gather_free_values!, local_views(free_values), local_views(f), local_views(cell_vals))
 end
 
-function FESpaces.gather_free_and_dirichlet_values!(free_vals,dir_vals,f::DistributedFESpace,cell_vals)
-  map_parts(gather_free_and_dirichlet_values!,local_views(free_vals), local_views(dir_vals), local_views(f), local_views(cell_vals))
+function FESpaces.gather_dirichlet_values!(dirichlet_values,f::SingleFieldFESpace,cell_vals)
+  map_parts(gather_dirichlet_values!, local_views(dirichlet_values), local_views(f), local_views(cell_vals))
+end
+
+function FESpaces.gather_free_and_dirichlet_values!(free_values,dirichlet_values,f::DistributedFESpace,cell_vals)
+  map_parts(gather_free_and_dirichlet_values!, local_views(free_values), local_views(dirichlet_values), local_views(f), local_views(cell_vals))
 end
 
 function dof_wise_to_cell_wise!(cell_wise_vector,dof_wise_vector,cell_to_ldofs,cell_prange)

--- a/src/FESpaces.jl
+++ b/src/FESpaces.jl
@@ -45,10 +45,6 @@ function FESpaces.gather_free_values!(free_values,f::DistributedFESpace,cell_val
   map_parts(gather_free_values!, local_views(free_values), local_views(f), local_views(cell_vals))
 end
 
-function FESpaces.gather_dirichlet_values!(dirichlet_values,f::SingleFieldFESpace,cell_vals)
-  map_parts(gather_dirichlet_values!, local_views(dirichlet_values), local_views(f), local_views(cell_vals))
-end
-
 function FESpaces.gather_free_and_dirichlet_values!(free_values,dirichlet_values,f::DistributedFESpace,cell_vals)
   map_parts(gather_free_and_dirichlet_values!, local_views(free_values), local_views(dirichlet_values), local_views(f), local_views(cell_vals))
 end

--- a/test/FESpacesTests.jl
+++ b/test/FESpacesTests.jl
@@ -68,6 +68,22 @@ function assemble_tests(das,dΩ,dΩass,U,V)
   b2=allocate_vector(assem,vecdata)
   assemble_vector!(b2,assem,vecdata)
   @test abs(sum(b2)-length(b2)) < 1.0e-12
+
+  free_vals = PVector(1.0,V.gids)
+  dir_vals  = get_dirichlet_dof_values(U)
+  uh        = FEFunction(U,free_vals)
+  dofs      = get_fe_dof_basis(U)
+  cell_vals = dofs(uh)
+
+  free_vals_bis = zero_free_values(U)
+  dir_vals_bis  = zero_dirichlet_values(U)
+  gather_free_values!(free_vals_bis,U,cell_vals)
+  gather_dirichlet_values!(dir_vals_bis,U,cell_vals)
+  @test free_vals_bis ≈ free_vals
+  @test dir_vals_bis  ≈ dir_vals
+  gather_free_and_dirichlet_values!(free_vals_bis,dir_vals_bis,U,cell_vals)
+  @test free_vals_bis ≈ free_vals
+  @test dir_vals_bis  ≈ dir_vals
 end
 
 


### PR DESCRIPTION
This PR has a couple of distributed Gridap wrappers that I've implemented when building the P-Multigrid solver. 
Mainly, we have: 

- A new wrapper structure `DistributedCellDof` for the Gridap counterpart. 
- Some extra non-implemented functions for `DistributedFESpace` which are implemented in Gridap. 

Everything works for my case, but I implemented things when I had no real knowledge on how GridapDistributed worked, so they should probably be looked at. 
If we consider this needs to be added to GridapDistributed, I can create the tests for all new features. 