### PR TITLE
Bugfix: Operating 3 or more CellFields 

### DIFF
--- a/src/CellData.jl
+++ b/src/CellData.jl
@@ -110,7 +110,7 @@ function Arrays.evaluate!(cache,k::Operation,b::Function,a::DistributedCellField
 end
 
 function Arrays.evaluate!(cache,k::Operation,a::DistributedCellField...)
-  fields = map_parts(map(i->i.fields,a)) do f...
+  fields = map_parts(map(i->i.fields,a)...) do f...
     evaluate!(nothing,k,f...)
   end
   DistributedCellField(fields)

--- a/test/CellDataTests.jl
+++ b/test/CellDataTests.jl
@@ -50,6 +50,12 @@ function main(parts)
   x_Γ = get_cell_points(dΓ)
   @test isa(f(x_Γ),AbstractPData)
 
+  _my_op(u,v,h) = u + v - h
+  u1 = CellField(0.0,Ω)
+  u2 = CellField(1.0,Ω)
+  u3 = CellField(2.0,Ω)
+  u = _my_op∘(u1,u2,u3)
+
 end
 
 end # module


### PR DESCRIPTION
Fixed a typo in the Operation of CellFields, where `...` was missing and causing an error. 