### PR TITLE
Block assemblers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["S. Badia <santiago.badia@monash.edu>", "A. F. Martin <alberto.f.mart
 version = "0.2.7"
 
 [deps]
+BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 Gridap = "56d4f2e9-7ea1-5844-9cf6-b9c51ca7ce8e"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/Algebra.jl
+++ b/src/Algebra.jl
@@ -102,6 +102,12 @@ function Algebra.nz_counter(
   DistributedCounterCOO(builder.par_strategy,counters,rows,cols)
 end
 
+function Algebra.get_array_type(::PSparseMatrixBuilderCOO{Tv}) where Tv
+  T = eltype(Tv)
+  return PSparseMatrix{T}
+end
+
+
 """
 """
 struct DistributedCounterCOO{A,B,C,D} <: DistributedGridapType
@@ -384,6 +390,11 @@ function Algebra.nz_counter(builder::PVectorBuilder,axs::Tuple{<:PRange})
     nz_counter(ArrayBuilder(T),axs)
   end
   PVectorCounter(builder.par_strategy,counters,rows)
+end
+
+function Algebra.get_array_type(::PVectorBuilder{Tv}) where Tv
+  T = eltype(Tv)
+  return PVector{T}
 end
 
 struct PVectorCounter{A,B,C}

--- a/src/FESpaces.jl
+++ b/src/FESpaces.jl
@@ -481,10 +481,21 @@ function _find_vector_type(spaces,gids)
   # new kw-arg global_vector_type ?
   # we use PVector for the moment
   local_vector_type = get_vector_type(get_part(spaces))
-  T = eltype(local_vector_type)
-  A = typeof(map_parts(i->local_vector_type(undef,0),gids.partition))
-  B = typeof(gids)
-  vector_type = PVector{T,A,B}
+
+  if local_vector_type <: BlockVector
+    T = eltype(local_vector_type)
+    A = typeof(map_parts(i->Vector{T}(undef,0),gids.partition))
+    B = typeof(gids)
+    block_type  = PVector{T,A,B}
+    vector_type = BlockVector{T,Vector{block_type}}
+  else
+    T = eltype(local_vector_type)
+    A = typeof(map_parts(i->local_vector_type(undef,0),gids.partition))
+    B = typeof(gids)
+    vector_type = PVector{T,A,B}
+  end
+
+  return vector_type
 end
 
 # Assembly

--- a/src/FESpaces.jl
+++ b/src/FESpaces.jl
@@ -486,8 +486,8 @@ function _find_vector_type(spaces,gids)
     T = eltype(local_vector_type)
     A = typeof(map_parts(i->Vector{T}(undef,0),gids.partition))
     B = typeof(gids)
-    block_type  = PVector{T,A,B}
-    vector_type = BlockVector{T,Vector{block_type}}
+    vector_type  = PVector{T,A,B}
+    #vector_type = BlockVector{T,Vector{block_type}}
   else
     T = eltype(local_vector_type)
     A = typeof(map_parts(i->local_vector_type(undef,0),gids.partition))

--- a/src/GridapDistributed.jl
+++ b/src/GridapDistributed.jl
@@ -21,6 +21,7 @@ const PArrays = PartitionedArrays
 using SparseArrays
 using WriteVTK
 using FillArrays
+using BlockArrays
 
 import Gridap.TensorValues: inner, outer, double_contraction, symmetric_part
 import LinearAlgebra: det, tr, cross, dot, ⋅

--- a/src/MultiField.jl
+++ b/src/MultiField.jl
@@ -432,10 +432,11 @@ end
 for fun in [:select_touched_blocks_matdata,:select_touched_blocks_vecdata,:select_touched_blocks_matvecdata]
   @eval begin
     function MultiField.$fun(data::AbstractPData,s::Tuple)
-      touched = map_parts(data) do data
-        MultiField.$fun(data,s)
-      end
-      return get_part(touched)
+      return fill(true,s)
+      #touched = map_parts(data) do data
+      #  MultiField.$fun(data,s)
+      #end
+      #return get_part(touched)
       #return reduce(.|,touched; init=fill(false,s))
     end
   end

--- a/src/MultiField.jl
+++ b/src/MultiField.jl
@@ -401,7 +401,7 @@ function FESpaces.SparseMatrixAssembler(
   block_tests  = map(range -> get_block_fespace(test.field_fe_space,range),block_ranges)
   block_trials = map(range -> get_block_fespace(trial.field_fe_space,range),block_ranges)
 
-  block_idx = CartesianIndices((length(test),length(trial)))
+  block_idx = CartesianIndices((NB,NB))
   block_assemblers = map(block_idx) do idx
     Yi = block_tests[idx[1]]; Xj = block_trials[idx[2]]
     return SparseMatrixAssembler(local_mat_type,local_vec_type,Xj,Yi,par_strategy)
@@ -451,6 +451,13 @@ function local_views(a::VectorBlock,rows)
       get_part(local_views(a[I],rows[I]),p)
     end
     ArrayBlock(array,a.touched)
+  end
+end
+
+function local_views(a::MultiField.ArrayBlockView,axes...)
+  array = local_views(a.array,axes...)
+  map_parts(array) do array
+    MultiField.ArrayBlockView(array,a.block_map)
   end
 end
 

--- a/src/MultiField.jl
+++ b/src/MultiField.jl
@@ -429,6 +429,18 @@ function MultiField.select_block_matvecdata(matvecdata::AbstractPData,i::Integer
   end
 end
 
+function MultiField.combine_matdata(data1::AbstractPData,data2::AbstractPData)
+  map_parts(data1,data2) do data1,data2
+    MultiField.combine_matdata(data1,data2)
+  end
+end
+
+function MultiField.recombine_data(matvecdata::AbstractPData,matdata::AbstractPData,vecdata::AbstractPData)
+  map_parts(matvecdata,matdata,vecdata) do matvecdata,matdata,vecdata
+    (matvecdata,matdata,vecdata)
+  end
+end
+
 for fun in [:select_touched_blocks_matdata,:select_touched_blocks_vecdata,:select_touched_blocks_matvecdata]
   @eval begin
     function MultiField.$fun(data::AbstractPData,s::Tuple)

--- a/src/MultiField.jl
+++ b/src/MultiField.jl
@@ -411,20 +411,26 @@ function FESpaces.SparseMatrixAssembler(
   SparseMatrixAssembler(Tm,Tv,trial,test,par_strategy)
 end
 
-function MultiField.select_block_matdata(matdata::AbstractPData,i::Integer,j::Integer)
-  map_parts(matdata) do matdata
-    MultiField.select_block_matdata(matdata,i,j)
+# select_block_Xdata
+for fun in [:select_block_matdata,:select_block_vecdata,:select_block_matvecdata]
+  @eval begin
+    function MultiField.$fun(data::AbstractPData,s::Tuple)
+      map_parts(data) do data
+        MultiField.$fun(data,s)
+      end
+    end
   end
 end
 
-function MultiField.select_block_vecdata(vecdata::AbstractPData,j::Integer)
-  map_parts(vecdata) do vecdata
-    MultiField.select_block_vecdata(vecdata,j)
-  end
-end
-
-function MultiField.select_block_matvecdata(matvecdata::AbstractPData,i::Integer,j::Integer)
-  map_parts(matvecdata) do matvecdata
-    MultiField.select_block_matvecdata(matvecdata,i,j)
+# select_touched_blocks_Xdata
+for fun in [:select_touched_blocks_matdata,:select_touched_blocks_vecdata,:select_touched_blocks_matvecdata]
+  @eval begin
+    function MultiField.$fun(data::AbstractPData,s::Tuple)
+      touched = map_parts(data) do data
+        MultiField.$fun(data,s)
+      end
+      return get_part(touched)
+      #return reduce(.|,touched; init=fill(false,s))
+    end
   end
 end

--- a/src/MultiField.jl
+++ b/src/MultiField.jl
@@ -239,11 +239,11 @@ end
 # Factory
 
 function MultiField.MultiFieldFESpace(
-  f_dspace::Vector{<:DistributedSingleFieldFESpace})
+  f_dspace::Vector{<:DistributedSingleFieldFESpace};kwargs...)
   f_p_space = map(local_views,f_dspace)
   v(x...) = collect(x)
   p_f_space = map_parts(v,f_p_space...)
-  p_mspace = map_parts(MultiFieldFESpace,p_f_space)
+  p_mspace = map_parts(f->MultiFieldFESpace(f;kwargs...),p_f_space)
   gids = generate_multi_field_gids(f_dspace,p_mspace)
   vector_type = _find_vector_type(p_mspace,gids)
   DistributedMultiFieldFESpace(f_dspace,p_mspace,gids,vector_type)

--- a/src/MultiField.jl
+++ b/src/MultiField.jl
@@ -401,6 +401,16 @@ function FESpaces.SparseMatrixAssembler(
   return BlockMatrixAssembler(block_assemblers)
 end
 
+function FESpaces.SparseMatrixAssembler(
+  trial::DistributedMultiFieldFESpace{<:BlockMultiFieldStyle},
+  test::DistributedMultiFieldFESpace{<:BlockMultiFieldStyle},
+  par_strategy=SubAssembledRows())
+  Tv = get_vector_type(get_part(local_views(first(trial))))
+  T  = eltype(Tv)
+  Tm = SparseMatrixCSC{T,Int}
+  SparseMatrixAssembler(Tm,Tv,trial,test,par_strategy)
+end
+
 function MultiField.select_block_matdata(matdata::AbstractPData,i::Integer,j::Integer)
   map_parts(matdata) do matdata
     MultiField.select_block_matdata(matdata,i,j)

--- a/test/BlockMatrixAssemblersTests.jl
+++ b/test/BlockMatrixAssemblersTests.jl
@@ -1,4 +1,4 @@
-using Test, LinearAlgebra, BlockArrays
+using Test, LinearAlgebra, BlockArrays, SparseArrays
 
 using Gridap
 using Gridap.FESpaces, Gridap.ReferenceFEs, Gridap.MultiField
@@ -18,7 +18,7 @@ V = FESpace(Ω, reffe)
 U = TrialFESpace(sol,V)
 
 dΩ = Measure(Ω, 4)
-biform((u1,u2,u3),(v1,v2,v3)) = ∫(∇(u1)⋅∇(v1) + u2⋅v2 + u1⋅v2 - u2⋅v1 - v3⋅u3 + v3⋅u1 - v1⋅u3)*dΩ
+biform((u1,u2,u3),(v1,v2,v3)) = ∫(∇(u1)⋅∇(v1) + u2⋅v2 + u1⋅v2 - u2⋅v1 - v3⋅u3)*dΩ # + v3⋅u1 - v1⋅u3)*dΩ
 liform((v1,v2,v3)) = ∫(v1 + v2 - v3)*dΩ
 
 ############################################################################################
@@ -125,3 +125,9 @@ mul!(y1,A1,x1)
 
 op = AffineFEOperator(biform,liform,X,Y)
 block_op = AffineFEOperator(biform,liform,Xb,Yb)
+
+
+A11 = A1_blocks.blocks[1,1]
+A12 = A1_blocks.blocks[1,2]
+A22 = A1_blocks.blocks[2,2]
+

--- a/test/BlockMatrixAssemblersTests.jl
+++ b/test/BlockMatrixAssemblersTests.jl
@@ -95,6 +95,26 @@ end
 
 assem_blocks = SparseMatrixAssembler(Xb,Yb,FullyAssembledRows())
 
+using Gridap.Fields: ArrayBlock, MatrixBlock, VectorBlock
+using Gridap.FESpaces: nz_counter, nz_allocation,create_from_nz
+using Gridap.FESpaces: symbolic_loop_matrix!, numeric_loop_matrix!
+using Gridap.Helpers
+using Gridap.FESpaces: get_assembly_strategy
+
+mat_builders = get_matrix_builder(assem_blocks)
+rows = get_rows(assem_blocks)
+cols = get_cols(assem_blocks)
+
+m1 = nz_counter(mat_builders,(rows,cols))
+symbolic_loop_matrix!(m1,assem_blocks,bmatdata)
+m2 = nz_allocation(m1)
+numeric_loop_matrix!(m2,assem_blocks,bmatdata)
+m3 = create_from_nz(m2)
+
+
+strat = get_assembly_strategy(assem_blocks)
+
+
 A1_blocks = assemble_matrix(assem_blocks,bmatdata);
 b1_blocks = assemble_vector(assem_blocks,bvecdata);
 

--- a/test/BlockMatrixAssemblersTests.jl
+++ b/test/BlockMatrixAssemblersTests.jl
@@ -10,14 +10,14 @@ parts = get_part_ids(SequentialBackend(),(2,2))
 
 sol(x) = sum(x)
 
-model = CartesianDiscreteModel(parts,(0.0,1.0,0.0,1.0),(6,6))
+model = CartesianDiscreteModel(parts,(0.0,1.0,0.0,1.0),(12,12))
 Ω = Triangulation(model)
 
 reffe = LagrangianRefFE(Float64,QUAD,1)
 V = FESpace(Ω, reffe)
 U = TrialFESpace(sol,V)
 
-dΩ = Measure(Ω, 2)
+dΩ = Measure(Ω, 4)
 biform((u1,u2),(v1,v2)) = ∫(∇(u1)⋅∇(v1) + u2⋅v2 + u1⋅v2)*dΩ
 liform((v1,v2)) = ∫(v1 + v2)*dΩ
 
@@ -34,10 +34,13 @@ data = collect_cell_matrix_and_vector(X,Y,biform(u,v),liform(v))
 matdata = collect_cell_matrix(X,Y,biform(u,v))
 vecdata = collect_cell_vector(Y,liform(v))  
 
-assem = SparseMatrixAssembler(X,Y)
+assem = SparseMatrixAssembler(X,Y,FullyAssembledRows())
 A1 = assemble_matrix(assem,matdata)
 b1 = assemble_vector(assem,vecdata)
 A2,b2 = assemble_matrix_and_vector(assem,data);
+
+assem11 = SparseMatrixAssembler(U,V,FullyAssembledRows())
+A11 = assemble_matrix((u1,v1)->∫(∇(u1)⋅∇(v1))*dΩ,assem11,U,V)
 
 ############################################################################################
 # Block MultiFieldStyle
@@ -56,19 +59,20 @@ bvecdata = collect_cell_vector(Yb,liform(vb))
 ############################################################################################
 # Block Assembly
 
-function same_vector(v1::PVector,v2::BlockVector,X)
-  v1i = map(i->restrict_to_field(X,v1,i),1:2)
-  for i in 1:length(v1i)
-    map_parts(v1i[i].owned_values,v2[Block(i)].owned_values) do v1,v2
-      @test (norm(v1 - v2) < 1.e-10)
-    end
+function same_solution(x1::PVector,x2::BlockVector,X,dΩ)
+  u1 = [FEFunction(X,x1)...]
+  u2 = map(i->FEFunction(X[i],x2[Block(i)]),1:blocklength(x2))
+
+  err = map(u1,u2) do u1,u2
+    eh = u1-u2
+    return sum(∫(eh⋅eh)dΩ)
   end
-  return true
+  return err
 end
 
 function LinearAlgebra.mul!(y::BlockVector,A::BlockMatrix,x::BlockVector)
   o = one(eltype(A))
-  for i in blockaxes(A,1)
+  for i in blockaxes(A,2)
     fill!(y[i],0.0)
     for j in blockaxes(A,2)
       mul!(y[i],A[i,j],x[j],o,o)
@@ -76,25 +80,37 @@ function LinearAlgebra.mul!(y::BlockVector,A::BlockMatrix,x::BlockVector)
   end
 end
 
-assem_blocks = SparseMatrixAssembler(Xb,Yb)
+function test_axes(c::BlockVector,a::BlockMatrix,b::BlockVector)
+  tests = []
+  for i in blockaxes(a,1)
+    for j in blockaxes(a,2)
+      push!(tests,
+      (oids_are_equal(c[i].rows,a[i,j].rows),
+      oids_are_equal(a[i,j].cols,b[j].rows),
+      hids_are_equal(a[i,j].cols,b[j].rows)))
+    end
+  end
+  return tests
+end
+
+assem_blocks = SparseMatrixAssembler(Xb,Yb,FullyAssembledRows())
 
 A1_blocks = assemble_matrix(assem_blocks,bmatdata);
 b1_blocks = assemble_vector(assem_blocks,bvecdata);
 
-y1_blocks = mortar(map(Aii->PVector(0.0,Aii.cols),A1_blocks.blocks[1,:]));
+y1_blocks = mortar(map(Aii->PVector(0.0,Aii.rows),A1_blocks.blocks[:,1]));
 x1_blocks = mortar(map(Aii->PVector(1.0,Aii.cols),A1_blocks.blocks[1,:]));
+test_axes(y1_blocks,A1_blocks,x1_blocks)
 
 mul!(y1_blocks,A1_blocks,x1_blocks)
 
-y1 = PVector(0.0,A1.cols)
+y1 = PVector(0.0,A1.rows)
 x1 = PVector(1.0,A1.cols)
 mul!(y1,A1,x1)
 
-@test same_vector(y1,y1_blocks,X)
-@test same_vector(b1,b1_blocks,Y)
+@test all(same_solution(y1,y1_blocks,X,dΩ) .< 1e-10)
 
 ############################################################################################
 
 op = AffineFEOperator(biform,liform,X,Y)
 block_op = AffineFEOperator(biform,liform,Xb,Yb)
-

--- a/test/BlockMatrixAssemblersTests.jl
+++ b/test/BlockMatrixAssemblersTests.jl
@@ -53,10 +53,6 @@ bdata = collect_cell_matrix_and_vector(Xb,Yb,biform(ub,vb),liform(vb))
 bmatdata = collect_cell_matrix(Xb,Yb,biform(ub,vb))
 bvecdata = collect_cell_vector(Yb,liform(vb))
 
-
-touched = MultiField.select_touched_blocks_vecdata(bvecdata,(2,1))
-
-
 ############################################################################################
 # Block Assembly
 

--- a/test/BlockMatrixAssemblersTests.jl
+++ b/test/BlockMatrixAssemblersTests.jl
@@ -1,4 +1,4 @@
-using Test, LinearAlgebra
+using Test, LinearAlgebra, BlockArrays
 
 using Gridap
 using Gridap.FESpaces, Gridap.ReferenceFEs, Gridap.MultiField
@@ -10,11 +10,11 @@ parts = get_part_ids(SequentialBackend(),(2,2))
 
 sol(x) = sum(x)
 
-model = CartesianDiscreteModel(parts,(0.0,1.0,0.0,1.0),(10,10))
+model = CartesianDiscreteModel(parts,(0.0,1.0,0.0,1.0),(6,6))
 Ω = Triangulation(model)
 
 reffe = LagrangianRefFE(Float64,QUAD,1)
-V = FESpace(Ω, reffe; dirichlet_tags="boundary")
+V = FESpace(Ω, reffe)
 U = TrialFESpace(sol,V)
 
 dΩ = Measure(Ω, 2)
@@ -54,3 +54,4 @@ bmatdata = collect_cell_matrix(Xb,Yb,biform(ub,vb))
 bvecdata = collect_cell_vector(Yb,liform(vb))
 
 assem_blocks = SparseMatrixAssembler(Xb,Yb)
+A_blocks = assemble_matrix(assem_blocks,bmatdata)

--- a/test/BlockMatrixAssemblersTests.jl
+++ b/test/BlockMatrixAssemblersTests.jl
@@ -53,6 +53,10 @@ bdata = collect_cell_matrix_and_vector(Xb,Yb,biform(ub,vb),liform(vb))
 bmatdata = collect_cell_matrix(Xb,Yb,biform(ub,vb))
 bvecdata = collect_cell_vector(Yb,liform(vb))
 
+
+touched = MultiField.select_touched_blocks_vecdata(bvecdata,(2,1))
+
+
 ############################################################################################
 # Block Assembly
 
@@ -93,36 +97,8 @@ mul!(y1,A1,x1)
 @test same_vector(y1,y1_blocks,X)
 @test same_vector(b1,b1_blocks,Y)
 
-
-tests = []
-for i in blockaxes(A1_blocks,1)
-  for j in blockaxes(A1_blocks,2)
-    push!(tests,(oids_are_equal(y1_blocks[i].rows,A1_blocks[i,j].rows),
-    oids_are_equal(A1_blocks[i,j].cols,x1_blocks[j].rows),
-    hids_are_equal(A1_blocks[i,j].cols,x1_blocks[j].rows)))
-  end
-end
-
-A2_blocks, b2_blocks = assemble_matrix_and_vector(assem_blocks,bdata)
-@test A2_blocks ≈ A2
-@test b2_blocks ≈ b2
-
-A3_blocks = allocate_matrix(assem_blocks,bmatdata)
-b3_blocks = allocate_vector(assem_blocks,bvecdata)
-assemble_matrix!(A3_blocks,assem_blocks,bmatdata)
-assemble_vector!(b3_blocks,assem_blocks,bvecdata)
-@test A3_blocks ≈ A1_blocks
-@test b3_blocks ≈ b1_blocks
-
-A4_blocks, b4_blocks = allocate_matrix_and_vector(assem_blocks,bdata)
-assemble_matrix_and_vector!(A4_blocks,b4_blocks,assem_blocks,bdata)
-@test A4_blocks ≈ A2_blocks
-@test b4_blocks ≈ b2_blocks
-
 ############################################################################################
 
 op = AffineFEOperator(biform,liform,X,Y)
 block_op = AffineFEOperator(biform,liform,Xb,Yb)
 
-@test get_matrix(op) ≈ get_matrix(block_op)
-@test get_vector(op) ≈ get_vector(block_op)

--- a/test/BlockMatrixAssemblersTests.jl
+++ b/test/BlockMatrixAssemblersTests.jl
@@ -46,8 +46,8 @@ A11 = assemble_matrix((u1,v1)->∫(∇(u1)⋅∇(v1))*dΩ,assem11,U,V)
 # Block MultiFieldStyle
 
 mfs = BlockMultiFieldStyle()
-Yb = MultiFieldFESpace([V,V];style=mfs)
-Xb = MultiFieldFESpace([U,U];style=mfs)
+Yb  = MultiFieldFESpace([V,V];style=mfs)
+Xb  = MultiFieldFESpace([U,U];style=mfs)
 
 ub = get_trial_fe_basis(Xb)
 vb = get_fe_basis(Yb)

--- a/test/BlockSparseMatrixAssemblersTests.jl
+++ b/test/BlockSparseMatrixAssemblersTests.jl
@@ -1,0 +1,56 @@
+using Test, LinearAlgebra
+
+using Gridap
+using Gridap.FESpaces, Gridap.ReferenceFEs, Gridap.MultiField
+
+using GridapDistributed
+using PartitionedArrays
+
+parts = get_part_ids(SequentialBackend(),(2,2))
+
+sol(x) = sum(x)
+
+model = CartesianDiscreteModel(parts,(0.0,1.0,0.0,1.0),(10,10))
+Ω = Triangulation(model)
+
+reffe = LagrangianRefFE(Float64,QUAD,1)
+V = FESpace(Ω, reffe; dirichlet_tags="boundary")
+U = TrialFESpace(sol,V)
+
+dΩ = Measure(Ω, 2)
+biform((u1,u2),(v1,v2)) = ∫(∇(u1)⋅∇(v1) + u2⋅v2 - u1⋅v2)*dΩ
+liform((v1,v2)) = ∫(v1 - v2)*dΩ
+
+############################################################################################
+# Normal assembly 
+
+Y = MultiFieldFESpace([V,V])
+X = MultiFieldFESpace([U,U])
+
+u = get_trial_fe_basis(X)
+v = get_fe_basis(Y)
+
+data = collect_cell_matrix_and_vector(X,Y,biform(u,v),liform(v))
+matdata = collect_cell_matrix(X,Y,biform(u,v))
+vecdata = collect_cell_vector(Y,liform(v))  
+
+assem = SparseMatrixAssembler(X,Y)
+A1 = assemble_matrix(assem,matdata)
+b1 = assemble_vector(assem,vecdata)
+A2,b2 = assemble_matrix_and_vector(assem,data);
+
+############################################################################################
+# Block MultiFieldStyle
+
+mfs = BlockMultiFieldStyle()
+Yb = MultiFieldFESpace([V,V];style=mfs)
+Xb = MultiFieldFESpace([U,U];style=mfs)
+
+ub = get_trial_fe_basis(Xb)
+vb = get_fe_basis(Yb)
+
+bdata = collect_cell_matrix_and_vector(Xb,Yb,biform(ub,vb),liform(vb))
+bmatdata = collect_cell_matrix(Xb,Yb,biform(ub,vb))
+bvecdata = collect_cell_vector(Yb,liform(vb))
+
+assem_blocks = SparseMatrixAssembler(Xb,Yb)


### PR DESCRIPTION
This PR implements block assemblers, which allow to assemble a MultiFieldFESpace block-wise. It is the distributed counterpart of [this other PR](https://github.com/gridap/Gridap.jl/pull/915). 

Instead of a sparse monolithic matrix and vectors, this assembler leverages BlockArrays.jl to produce equivalent block-partitioned sparse matrices and vectors. This is meant to ease the development of block preconditioners and solvers.

**TODO:**

- [ ] Find a reliable way to compare solutions between block-assembled and monolothic systems. 
- [ ] Right now we have a problem dealing with different blocks having different `PRanges`. This complicates the allocation of a single column vector for the whole matrix, since ghosts do not match when multiplying with different blocks in the same block column. We will have to homogenize the row/col ghost values for all blocks in the same row/column by comparing them and keeping the biggest set. 
- [ ] Should we move the block linear algebra operations here from GridapSolvers? 

Other pains/doubts about the implementation can be found in [this issue](https://github.com/gridap/GridapSolvers.jl/issues/29). 

