### PR TITLE
Bugfix: Failing transient tests

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,21 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.3.0] - 2023-08-16
 
-### Changed 
+### Changed
 
 - Porting the whole library to PartitionedArrays v0.3.x. Since PR [114](https://github.com/gridap/GridapDistributed.jl/pull/114)
 
-### Added 
+### Added
 
 - Tools for redistributing FE functions among meshes; added mock tests for `RedistributeGlue`. Since PR [114](https://github.com/gridap/GridapDistributed.jl/pull/114). This functionality was already somewhere else in the Gridap ecosystem of packages (in GridapSolvers.jl in particular).
 - A variant of the PArrays `assemble_coo!` function named `assemble_coo_with_column_owner!` which also exchanges processor column owners of the entries. This variant is required to circumvent the current limitation of GridapDistributed.jl assembly for the case in which the following is not fullfilled: "each processor can determine locally with a single layer of ghost cells the global indices and associated processor owners of the rows that it touches after assembly of integration terms posed on locally-owned entities." Since PR [115](https://github.com/gridap/GridapDistributed.jl/pull/115).
 
+### Fixed
+
+- Added missing parameter to `allocate_jacobian`, needed after Gridap v0.17.18. Since PR [126](https://github.com/gridap/GridapDistributed.jl/pull/126). 
 
 ## [0.2.8] - 2023-07-31
 
 ### Added
+
 - Reverted some changes introduced in PR [98](https://github.com/gridap/GridapDistributed.jl/pull/98). Eliminated `DistributedGridapType`. Functions `local_views` and `get_parts` now take argument of type `Any`. Since PR [117](https://github.com/gridap/GridapDistributed.jl/pull/117).
 
 ### Fixed

--- a/src/TransientFESpaces.jl
+++ b/src/TransientFESpaces.jl
@@ -17,18 +17,10 @@ end
 
 function ODETools.allocate_jacobian(
   op::TransientFETools.TransientFEOperatorFromWeakForm,
-  duh::DistributedCellField,
+  t0::Real,
+  duh::Union{DistributedCellField,DistributedMultiFieldFEFunction},
   cache)
-  _matdata_jacobians = TransientFETools.fill_initial_jacobians(op,duh)
-  matdata = _vcat_distributed_matdata(_matdata_jacobians)
-  allocate_matrix(op.assem_t,matdata)
-end
-
-function ODETools.allocate_jacobian(
-  op::TransientFETools.TransientFEOperatorFromWeakForm,
-  duh::DistributedMultiFieldFEFunction,
-  cache)
-  _matdata_jacobians = TransientFETools.fill_initial_jacobians(op,duh)
+  _matdata_jacobians = TransientFETools.fill_initial_jacobians(op,t0,duh)
   matdata = _vcat_distributed_matdata(_matdata_jacobians)
   allocate_matrix(op.assem_t,matdata)
 end

--- a/test/StokesOpenBoundaryTests.jl
+++ b/test/StokesOpenBoundaryTests.jl
@@ -103,7 +103,7 @@ function main(distribute,parts)
   for (xh_tn, tn) in sol_t
     uh_tn = xh_tn[1]
     ph_tn = xh_tn[2]
-    writevtk(Ω,"output/tmp_stokes_OB_sol_$tn",cellfields=["u"=>uh_tn,"p"=>ph_tn])
+    writevtk(Ω,"output/tmp_stokes_OB_sol_$tn.vtu",cellfields=["u"=>uh_tn,"p"=>ph_tn])
     e = u(tn) - uh_tn
     el2 = sqrt(sum( ∫(l2(e))dΩ ))
     e = p(tn) - ph_tn

--- a/test/sequential/PeriodicBCsTests.jl
+++ b/test/sequential/PeriodicBCsTests.jl
@@ -13,7 +13,6 @@ ndofss = [25,20,20,16]
 for np in nps
   for (ndofs, isperiodic) in zip(ndofss,isperiodics)
     parts = DebugArray(LinearIndices((prod(np),)))
-    println(isperiodic)
     model = CartesianDiscreteModel(parts,np,domain,cells;isperiodic=isperiodic)
     V = FESpace(model,reffe)
     @test ndofs == num_free_dofs(V)

--- a/test/sequential/StokesHdivDGTests.jl
+++ b/test/sequential/StokesHdivDGTests.jl
@@ -1,4 +1,4 @@
-module StokesHdivDGTests
+module StokesHdivDGTestsSeq
 using PartitionedArrays
 include("../StokesHdivDGTests.jl")
 with_debug() do distribute


### PR DESCRIPTION
This PR solves the issues in the transient tests after the new release Gridap v0.17.18. 