### PR TITLE
Exploring ghost optimisation

### DIFF
--- a/src/Algebra.jl
+++ b/src/Algebra.jl
@@ -186,6 +186,13 @@ function change_ghost(::Type{<:OwnAndGhostVectors},a::PVector,ids::PRange)
   return PVector(values,partition(ids))
 end
 
+function change_ghost(a::BlockPVector,ids::BlockPRange;is_consistent=false,make_consistent=false)
+  vals = map(blocks(a),blocks(ids)) do a, ids
+    change_ghost(a,ids;is_consistent=is_consistent,make_consistent=make_consistent)
+  end
+  return BlockPVector(vals,ids)
+end
+
 # This function computes a mapping among the local identifiers of a and b
 # for which the corresponding global identifiers are both in a and b. 
 # Note that the haskey check is necessary because in the general case 

--- a/src/Algebra.jl
+++ b/src/Algebra.jl
@@ -180,7 +180,8 @@ end
 function change_ghost(::Type{<:OwnAndGhostVectors},a::PVector,ids::PRange)
   values = map(own_values(a),partition(ids)) do own_vals,ids
     ghost_vals = fill(zero(eltype(a)),ghost_length(ids))
-    OwnAndGhostVectors(own_vals,ghost_vals,ids)
+    perm = PartitionedArrays.local_permutation(ids)
+    OwnAndGhostVectors(own_vals,ghost_vals,perm)
   end
   return PVector(values,partition(ids))
 end

--- a/src/Algebra.jl
+++ b/src/Algebra.jl
@@ -16,6 +16,25 @@ function change_axes(a::Algebra.AllocationCOO{T,A}, axes::A) where {T,A}
   Algebra.AllocationCOO(counter,a.I,a.J,a.V)
 end
 
+# Array of PArrays -> PArray of Arrays 
+function to_parray_of_arrays(a::AbstractArray{<:MPIArray})
+  indices = linear_indices(first(a))
+  map(indices) do i
+    map(a) do aj
+      PartitionedArrays.getany(aj)
+    end
+  end
+end
+
+function to_parray_of_arrays(a::AbstractArray{<:DebugArray})
+  indices = linear_indices(first(a))
+  map(indices) do i
+    map(a) do aj
+      aj.items[i]
+    end
+  end
+end
+
 # This type is required because MPIArray from PArrays 
 # cannot be instantiated with a NULL communicator
 struct MPIVoidVector{T} <: AbstractVector{T}

--- a/src/Algebra.jl
+++ b/src/Algebra.jl
@@ -1009,8 +1009,6 @@ function assemble_coo_with_column_owner!(I,J,V,row_partition,Jown)
   end
 end
 
-Base.wait(t::Matrix) = map(wait,t)
-
 # dofs_gids_prange can be either test_dofs_gids_prange or trial_dofs_gids_prange
 # In the former case, gids is a vector of global test dof identifiers, while in the 
 # latter, a vector of global trial dof identifiers

--- a/src/Algebra.jl
+++ b/src/Algebra.jl
@@ -284,8 +284,12 @@ function local_views(row_col_partitioned_matrix::PSparseMatrix,
     end
 end
 
-function Algebra.allocate_vector(::Type{<:PVector{T}},ids::PRange) where {T}
-  PVector{T}(undef,partition(ids))
+function Algebra.allocate_vector(::Type{<:PVector{V}},ids::PRange) where {V}
+  PVector{V}(undef,partition(ids))
+end
+
+function Algebra.allocate_vector(::Type{<:BlockPVector{V}},ids::BlockPRange) where {V}
+  BlockPVector{V}(undef,ids)
 end
 
 # PSparseMatrix assembly

--- a/src/BlockPartitionedArrays.jl
+++ b/src/BlockPartitionedArrays.jl
@@ -242,7 +242,7 @@ end
 
 function LinearAlgebra.fillstored!(a::BlockPMatrix,v)
   map(blocks(a)) do a
-    fillstored!(a,v)
+    LinearAlgebra.fillstored!(a,v)
   end
   return a
 end

--- a/src/BlockPartitionedArrays.jl
+++ b/src/BlockPartitionedArrays.jl
@@ -1,0 +1,274 @@
+
+"""
+"""
+struct BlockPRange{A} <: AbstractUnitRange{Int}
+  ranges::Vector{PRange{A}}
+  function BlockPRange(ranges::Vector{<:PRange{A}}) where A
+    new{A}(ranges)
+  end
+end
+
+Base.first(a::BlockPRange) = 1
+Base.last(a::BlockPRange) = sum(map(last,a.ranges))
+
+BlockArrays.blocklength(a::BlockPRange) = length(a.ranges)
+BlockArrays.blocksize(a::BlockPRange) = (blocklength(a),)
+BlockArrays.blockaxes(a::BlockPRange) = (Block.(Base.OneTo(blocklength(a))),)
+BlockArrays.blocks(a::BlockPRange) = a.ranges
+
+"""
+"""
+struct BlockPArray{T,N,A,B} <: BlockArrays.AbstractBlockArray{T,N}
+  blocks::Array{A,N}
+  axes::NTuple{N,B}
+
+  function BlockPArray(blocks::Array{<:AbstractArray{T,N},N},
+                       axes  ::NTuple{N,<:BlockPRange}) where {T,N}
+    @check all(map(d->size(blocks,d)==blocklength(axes[d]),1:N))
+    A = eltype(blocks)
+    B = typeof(first(axes))
+    new{T,N,A,B}(blocks,axes)
+  end
+end
+
+const BlockPVector{T,A,B} = BlockPArray{T,1,A,B}
+const BlockPMatrix{T,A,B} = BlockPArray{T,2,A,B}
+
+@inline function BlockPVector(blocks::Vector{<:PVector},rows::BlockPRange)
+  BlockPArray(blocks,(rows,))
+end
+
+@inline function BlockPVector(blocks::Vector{<:PVector},rows::Vector{<:PRange})
+  BlockPVector(blocks,BlockPRange(rows))
+end
+
+@inline function BlockPMatrix(blocks::Matrix{<:PSparseMatrix},rows::BlockPRange,cols::BlockPRange)
+  BlockPArray(blocks,(rows,cols))
+end
+
+@inline function BlockPMatrix(blocks::Matrix{<:PSparseMatrix},rows::Vector{<:PRange},cols::Vector{<:PRange})
+  BlockPMatrix(blocks,BlockPRange(rows),BlockPRange(cols))
+end
+
+# AbstractArray API
+
+Base.axes(a::BlockPArray) = a.axes
+Base.size(a::BlockPArray) = Tuple(map(length,a.axes))
+
+Base.IndexStyle(::Type{<:BlockPVector}) = IndexLinear()
+Base.IndexStyle(::Type{<:BlockPMatrix}) = IndexCartesian()
+
+function Base.similar(a::BlockPVector,::Type{T},inds::Tuple{<:BlockPRange}) where T
+  vals = map(blocks(a),blocks(inds[1])) do ai,i
+    similar(ai,T,i)
+  end
+  return BlockPArray(vals,inds)
+end
+
+function Base.similar(::Type{<:BlockPVector{T,A}},inds::Tuple{<:BlockPRange}) where {T,A}
+  rows   = blocks(inds[1])
+  values = map(rows) do r
+    return similar(A,(r,))
+  end
+  return BlockPArray(values,inds)
+end
+
+function Base.similar(a::BlockPMatrix,::Type{T},inds::Tuple{<:BlockPRange,<:BlockPRange}) where T
+  vals = map(CartesianIndices(blocksize(a))) do I
+    rows = inds[1].ranges[I[1]]
+    cols = inds[2].ranges[I[2]]
+    similar(a.blocks[I],T,(rows,cols))
+  end
+  return BlockPArray(vals,inds)
+end
+
+function Base.similar(::Type{<:BlockPMatrix{T,A}},inds::Tuple{<:BlockPRange,<:BlockPRange}) where {T,A}
+  rows = blocks(inds[1])
+  cols = blocks(inds[2])
+  values = map(CartesianIndices((length(rows),length(cols)))) do I
+    i,j = I[1],I[2]
+    return similar(A,(rows[i],cols[j]))
+  end
+  return BlockPArray(values,inds)
+end
+
+function Base.getindex(a::BlockPArray{T,N},inds::Vararg{Int,N}) where {T,N}
+  @error "Scalar indexing not supported"
+end
+function Base.setindex(a::BlockPArray{T,N},v,inds::Vararg{Int,N}) where {T,N}
+  @error "Scalar indexing not supported"
+end
+
+function Base.show(io::IO,k::MIME"text/plain",data::BlockPArray{T,N}) where {T,N}
+  v = first(blocks(data))
+  s = prod(map(si->"$(si)x",blocksize(data)))[1:end-1]
+  map_main(partition(v)) do values
+      println(io,"$s-block BlockPArray{$T,$N}")
+  end
+end
+
+function Base.zero(v::BlockPArray)
+  return mortar(map(zero,blocks(v)))
+end
+
+function Base.copyto!(y::BlockPVector,x::BlockPVector)
+  @check blocklength(x) == blocklength(y)
+  for i in blockaxes(x,1)
+    copyto!(y[i],x[i])
+  end
+  return y
+end
+
+function Base.copyto!(y::BlockPMatrix,x::BlockPMatrix)
+  @check blocksize(x) == blocksize(y)
+  for i in blockaxes(x,1)
+    for j in blockaxes(x,2)
+      copyto!(y[i,j],x[i,j])
+    end
+  end
+  return y
+end
+
+function Base.fill!(a::BlockPVector,v)
+  map(blocks(a)) do a
+    fill!(a,v)
+  end
+  return a
+end
+
+# AbstractBlockArray API
+
+BlockArrays.blocks(a::BlockPArray) = a.blocks
+
+function Base.getindex(a::BlockPArray,inds::Block{1})
+  a.blocks[inds.n...]
+end
+function Base.getindex(a::BlockPArray{T,N},inds::Block{N}) where {T,N}
+  a.blocks[inds.n...]
+end
+function Base.getindex(a::BlockPArray{T,N},inds::Vararg{Block{1},N}) where {T,N}
+  a.blocks[map(i->i.n[1],inds)...]
+end
+
+function BlockArrays.mortar(blocks::Vector{<:PVector})
+  rows = map(b->axes(b,1),blocks)
+  BlockPVector(blocks,rows)
+end
+
+function BlockArrays.mortar(blocks::Matrix{<:PSparseMatrix})
+  rows = map(b->axes(b,1),blocks[:,1])
+  cols = map(b->axes(b,2),blocks[1,:])
+
+  function check_axes(a,r,c)
+    A = matching_local_indices(axes(a,1),r)
+    B = matching_local_indices(axes(a,2),c)
+    return A & B
+  end
+  @check all(map(I -> check_axes(blocks[I],rows[I[1]],cols[I[2]]),CartesianIndices(size(blocks))))
+
+  return BlockPMatrix(blocks,rows,cols)
+end
+
+# PartitionedArrays API
+
+Base.wait(t::Array)  = map(wait,t)
+Base.fetch(t::Array) = map(fetch,t)
+
+function PartitionedArrays.assemble!(a::BlockPArray)
+  map(assemble!,blocks(a))
+end
+
+function PartitionedArrays.consistent!(a::BlockPArray)
+  map(consistent!,blocks(a))
+end
+
+function PartitionedArrays.partition(a::BlockPArray)
+  return map(partition,blocks(a)) |> to_parray_of_arrays
+end
+
+function PartitionedArrays.to_trivial_partition(a::BlockPArray)
+  vals = map(to_trivial_partition,blocks(a))
+  return mortar(vals)
+end
+
+# LinearAlgebra API
+
+function LinearAlgebra.mul!(y::BlockPVector,A::BlockPMatrix,x::BlockPVector)
+  o = one(eltype(A))
+  for i in blockaxes(A,2)
+    fill!(y[i],0.0)
+    for j in blockaxes(A,2)
+      mul!(y[i],A[i,j],x[j],o,o)
+    end
+  end
+end
+
+function LinearAlgebra.dot(x::BlockPVector,y::BlockPVector)
+  return sum(map(dot,blocks(x),blocks(y)))
+end
+
+function LinearAlgebra.norm(v::BlockPVector)
+  block_norms = map(norm,blocks(v))
+  return sqrt(sum(block_norms.^2))
+end
+
+function LinearAlgebra.fillstored!(a::BlockPMatrix,v)
+  map(blocks(a)) do a
+    fillstored!(a,v)
+  end
+  return a
+end
+
+# Broadcasting
+
+struct BlockPBroadcasted{A,B}
+  blocks :: A
+  axes   :: B
+end
+
+BlockArrays.blocks(b::BlockPBroadcasted) = b.blocks
+BlockArrays.blockaxes(b::BlockPBroadcasted) = b.axes
+
+function Base.broadcasted(f, args::Union{BlockPVector,BlockPBroadcasted}...)
+  a1 = first(args)
+  @boundscheck @assert all(ai -> blockaxes(ai) == blockaxes(a1),args)
+  
+  blocks_in = map(blocks,args)
+  blocks_out = map((largs...)->Base.broadcasted(f,largs...),blocks_in...)
+  
+  return BlockPBroadcasted(blocks_out,blockaxes(a1))
+end
+
+function Base.broadcasted(f, a::Number, b::Union{BlockPVector,BlockPBroadcasted})
+  blocks_out = map(b->Base.broadcasted(f,a,b),blocks(b))
+  return BlockPBroadcasted(blocks_out,blockaxes(b))
+end
+
+function Base.broadcasted(f, a::Union{BlockPVector,BlockPBroadcasted}, b::Number)
+  blocks_out = map(a->Base.broadcasted(f,a,b),blocks(a))
+  return BlockPBroadcasted(blocks_out,blockaxes(a))
+end
+
+function Base.broadcasted(f,
+                        a::Union{BlockPVector,BlockPBroadcasted},
+                        b::Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{0}})
+  Base.broadcasted(f,a,Base.materialize(b))
+end
+
+function Base.broadcasted(
+  f,
+  a::Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{0}},
+  b::Union{BlockPVector,BlockPBroadcasted})
+  Base.broadcasted(f,Base.materialize(a),b)
+end
+
+function Base.materialize(b::BlockPBroadcasted)
+  blocks_out = map(Base.materialize,blocks(b))
+  return mortar(blocks_out)
+end
+
+function Base.materialize!(a::BlockPVector,b::BlockPBroadcasted)
+  map(Base.materialize!,blocks(a),blocks(b))
+  return a
+end
+

--- a/src/BlockPartitionedArrays.jl
+++ b/src/BlockPartitionedArrays.jl
@@ -186,7 +186,7 @@ function Base.any(f::Function,x::BlockPVector)
   any(map(xi->any(f,xi),blocks(x)))
 end
 
-function Base.all(f::Function,x::PVector)
+function Base.all(f::Function,x::BlockPVector)
   all(map(xi->all(f,xi),blocks(x)))
 end
 

--- a/src/BlockPartitionedArrays.jl
+++ b/src/BlockPartitionedArrays.jl
@@ -160,8 +160,8 @@ function BlockArrays.mortar(blocks::Matrix{<:PSparseMatrix})
   cols = map(b->axes(b,2),blocks[1,:])
 
   function check_axes(a,r,c)
-    A = matching_local_indices(axes(a,1),r)
-    B = matching_local_indices(axes(a,2),c)
+    A = PartitionedArrays.matching_local_indices(axes(a,1),r)
+    B = PartitionedArrays.matching_local_indices(axes(a,2),c)
     return A & B
   end
   @check all(map(I -> check_axes(blocks[I],rows[I[1]],cols[I[2]]),CartesianIndices(size(blocks))))
@@ -183,7 +183,8 @@ function PartitionedArrays.consistent!(a::BlockPArray)
 end
 
 function PartitionedArrays.partition(a::BlockPArray)
-  return map(partition,blocks(a)) |> to_parray_of_arrays
+  vals = map(partition,blocks(a)) |> to_parray_of_arrays
+  return map(mortar,vals)
 end
 
 function PartitionedArrays.to_trivial_partition(a::BlockPArray)

--- a/src/BlockPartitionedArrays.jl
+++ b/src/BlockPartitionedArrays.jl
@@ -190,6 +190,11 @@ function Base.all(f::Function,x::BlockPVector)
   all(map(xi->all(f,xi),blocks(x)))
 end
 
+function LinearAlgebra.rmul!(a::BlockPVector,v::Number)
+  map(ai->rmul!(ai,v),blocks(a))
+  return a
+end
+
 # AbstractBlockArray API
 
 BlockArrays.blocks(a::BlockPArray) = a.blocks

--- a/src/BlockPartitionedArrays.jl
+++ b/src/BlockPartitionedArrays.jl
@@ -16,6 +16,10 @@ BlockArrays.blocksize(a::BlockPRange) = (blocklength(a),)
 BlockArrays.blockaxes(a::BlockPRange) = (Block.(Base.OneTo(blocklength(a))),)
 BlockArrays.blocks(a::BlockPRange) = a.ranges
 
+function PartitionedArrays.partition(a::BlockPRange)
+  return map(partition,blocks(a)) |> to_parray_of_arrays
+end
+
 """
 """
 struct BlockPArray{T,N,A,B} <: BlockArrays.AbstractBlockArray{T,N}
@@ -195,9 +199,10 @@ end
 # LinearAlgebra API
 
 function LinearAlgebra.mul!(y::BlockPVector,A::BlockPMatrix,x::BlockPVector)
+  z = zero(eltype(y))
   o = one(eltype(A))
   for i in blockaxes(A,2)
-    fill!(y[i],0.0)
+    fill!(y[i],z)
     for j in blockaxes(A,2)
       mul!(y[i],A[i,j],x[j],o,o)
     end

--- a/src/FESpaces.jl
+++ b/src/FESpaces.jl
@@ -627,12 +627,12 @@ end
 
 # When using this one, make sure that you also loop over ghost cells.
 # This is at your own risk.
-function local_assembly_strategy(::FullyAssembledRows,test_space_indices,trial_space_indices)
-  test_space_local_to_ghost = local_to_ghost(test_space_indices)
+function local_assembly_strategy(::FullyAssembledRows,rows,cols)
+  rows_local_to_ghost = local_to_ghost(rows)
   GenericAssemblyStrategy(
     identity,
     identity,
-    row->test_space_local_to_ghost[row]==0,
+    row->rows_local_to_ghost[row]==0,
     col->true)
 end
 

--- a/src/FESpaces.jl
+++ b/src/FESpaces.jl
@@ -125,10 +125,6 @@ function fetch_vector_ghost_values!(vector_partition,cache)
   assemble!((a,b)->b, vector_partition, cache) 
 end
 
-function change_ghost(a,f::DistributedFESpace)
-  change_ghost(a,f.gids)
-end
-
 function generate_gids(
   cell_range::PRange,
   cell_to_ldofs::AbstractArray{<:AbstractArray},

--- a/src/FESpaces.jl
+++ b/src/FESpaces.jl
@@ -125,7 +125,7 @@ function fetch_vector_ghost_values!(vector_partition,cache)
   assemble!((a,b)->b, vector_partition, cache) 
 end
 
-function change_ghost(a::PVector,f::DistributedFESpace)
+function change_ghost(a,f::DistributedFESpace)
   change_ghost(a,f.gids)
 end
 

--- a/src/FESpaces.jl
+++ b/src/FESpaces.jl
@@ -495,7 +495,11 @@ function _find_vector_type(spaces,gids;own_and_ghost=false)
   if own_and_ghost
     T = OwnAndGhostVectors{T}
   end
-  vector_type = typeof(PVector{T}(undef,partition(gids)))
+  if isa(gids,PRange)
+    vector_type = typeof(PVector{T}(undef,partition(gids)))
+  else # isa(gids,BlockPRange)
+    vector_type = typeof(BlockPVector{T}(undef,gids))
+  end
   return vector_type
 end
 

--- a/src/GridapDistributed.jl
+++ b/src/GridapDistributed.jl
@@ -40,9 +40,9 @@ export get_face_gids
 export local_views, get_parts
 export with_ghost, no_ghost
 
-include("Algebra.jl")
-
 include("BlockPartitionedArrays.jl")
+
+include("Algebra.jl")
 
 include("Geometry.jl")
 

--- a/src/GridapDistributed.jl
+++ b/src/GridapDistributed.jl
@@ -23,6 +23,7 @@ using SparseArrays
 using WriteVTK
 using FillArrays
 using BlockArrays
+using LinearAlgebra
 
 import Gridap.TensorValues: inner, outer, double_contraction, symmetric_part
 import LinearAlgebra: det, tr, cross, dot, ⋅, diag
@@ -40,6 +41,8 @@ export local_views, get_parts
 export with_ghost, no_ghost
 
 include("Algebra.jl")
+
+include("BlockPartitionedArrays.jl")
 
 include("Geometry.jl")
 

--- a/src/MultiField.jl
+++ b/src/MultiField.jl
@@ -450,25 +450,6 @@ function FESpaces.SparseMatrixAssembler(
   return MultiField.BlockSparseMatrixAssembler{NB,NV,SB,P}(block_assemblers)
 end
 
-# Array of PArrays -> PArray of Arrays 
-function to_parray_of_arrays(a::AbstractArray{<:MPIArray})
-  indices = linear_indices(first(a))
-  map(indices) do i
-    map(a) do aj
-      PartitionedArrays.getany(aj)
-    end
-  end
-end
-
-function to_parray_of_arrays(a::AbstractArray{<:DebugArray})
-  indices = linear_indices(first(a))
-  map(indices) do i
-    map(a) do aj
-      aj.items[i]
-    end
-  end
-end
-
 function local_views(a::MultiField.BlockSparseMatrixAssembler{NB,NV,SB,P}) where {NB,NV,SB,P}
   assems = a.block_assemblers
   array = to_parray_of_arrays(map(local_views,assems))

--- a/src/MultiField.jl
+++ b/src/MultiField.jl
@@ -71,18 +71,6 @@ function MultiField.restrict_to_field(
   PVector(values,partition(gids))
 end
 
-function change_ghost(x::BlockPVector,
-                      X::DistributedMultiFieldFESpace{<:BlockMultiFieldStyle{NB,SB,P}}) where {NB,SB,P}
-  array = map(blocks(X.gids),blocks(x)) do gids, xi
-    change_ghost(xi,gids)
-  end
-  return BlockPVector(array,X.gids)
-end
-
-#function FESpaces.zero_free_values(f::DistributedMultiFieldFESpace{<:BlockMultiFieldStyle})
-#  return mortar(map(zero_free_values,f.field_fe_space))
-#end
-
 function FESpaces.FEFunction(
   f::DistributedMultiFieldFESpace,x::AbstractVector,isconsistent=false)
   free_values  = change_ghost(x,f.gids;is_consistent=isconsistent,make_consistent=true)

--- a/src/MultiField.jl
+++ b/src/MultiField.jl
@@ -236,7 +236,7 @@ end
 # Factory
 
 function MultiField.MultiFieldFESpace(
-  f_dspace::Vector{<:DistributedSingleFieldFESpace};own_and_ghost=false, kwargs...)
+  f_dspace::Vector{<:DistributedSingleFieldFESpace};split_own_and_ghost=false, kwargs...)
   f_p_space = map(local_views,f_dspace)
   v(x...) = collect(x)
 
@@ -244,7 +244,7 @@ function MultiField.MultiFieldFESpace(
   p_mspace    = map(f->MultiFieldFESpace(f;kwargs...),p_f_space)
   style       = PartitionedArrays.getany(map(MultiFieldStyle,p_mspace))
   gids        = generate_multi_field_gids(style,f_dspace,p_mspace)
-  vector_type = _find_vector_type(p_mspace,gids;own_and_ghost=own_and_ghost)
+  vector_type = _find_vector_type(p_mspace,gids;split_own_and_ghost=split_own_and_ghost)
   DistributedMultiFieldFESpace(f_dspace,p_mspace,gids,vector_type)
 end
 

--- a/src/MultiField.jl
+++ b/src/MultiField.jl
@@ -269,14 +269,14 @@ end
 # Factory
 
 function MultiField.MultiFieldFESpace(
-  f_dspace::Vector{<:DistributedSingleFieldFESpace};kwargs...)
+  f_dspace::Vector{<:DistributedSingleFieldFESpace};own_and_ghost=false, kwargs...)
   f_p_space = map(local_views,f_dspace)
   v(x...) = collect(x)
 
   p_f_space   = map(v,f_p_space...)
   p_mspace    = map(f->MultiFieldFESpace(f;kwargs...),p_f_space)
   gids        = generate_multi_field_gids(f_dspace,p_mspace)
-  vector_type = _find_vector_type(p_mspace,gids)
+  vector_type = _find_vector_type(p_mspace,gids;own_and_ghost=own_and_ghost)
 
   style = MultiFieldStyle(PartitionedArrays.getany(p_mspace))
   block_gids = _generate_block_gids(style,f_dspace)

--- a/test/BlockPartitionedArraysTests.jl
+++ b/test/BlockPartitionedArraysTests.jl
@@ -1,0 +1,89 @@
+
+using Test
+using Gridap
+using PartitionedArrays
+using GridapDistributed
+using BlockArrays
+using SparseArrays
+using LinearAlgebra
+
+using GridapDistributed: BlockPArray, BlockPVector, BlockPMatrix, BlockPRange
+
+
+ranks = with_debug() do distribute
+  distribute(LinearIndices((2,)))
+end
+
+indices = map(ranks) do r
+  if r == 1
+    own_gids = [1,2,3,4,5]
+    ghost_gids   = [6,7]
+    ghost_owners = [2,2]
+  else
+    own_gids = [6,7,8,9,10]
+    ghost_gids   = [5]
+    ghost_owners = [1]
+  end
+  own_idx   = OwnIndices(10,r,own_gids)
+  ghost_idx = GhostIndices(10,ghost_gids,ghost_owners)
+  OwnAndGhostIndices(own_idx,ghost_idx)
+end
+
+block_range = BlockPRange([PRange(indices),PRange(indices)])
+
+_v = PVector{OwnAndGhostVectors{Vector{Float64}}}(undef,indices)
+v = BlockPArray([_v,_v],(block_range,))
+
+_m = map(CartesianIndices((2,2))) do I
+  i,j = I[1],I[2]
+  local_mats = map(ranks,indices) do r, ind
+    n = local_length(ind)
+    if i==j && r == 1
+      SparseMatrixCSC(n,n,Int[1,3,5,7,9,10,11,13],Int[1,2,2,3,3,4,4,5,5,6,6,7],fill(1.0,12))
+    elseif i==j && r == 2
+      SparseMatrixCSC(n,n,Int[1,2,4,6,8,10,11],Int[1,1,2,2,3,3,4,4,5,6],fill(1.0,10))
+    else
+      SparseMatrixCSC(n,n,fill(Int(1),n+1),Int[],Float64.([]))
+    end
+  end
+  PSparseMatrix(local_mats,indices,indices)
+end
+m = BlockPArray(_m,(block_range,block_range))
+
+x = similar(_v)
+mul!(x,_m[1,1],_v)
+
+# BlockPRange
+
+@test blocklength(block_range) == 2
+@test blocksize(block_range) == (2,)
+
+# BlockPArray
+
+__v = similar(v,block_range)
+__m = similar(m,(block_range,block_range))
+fill!(v,1.0)
+
+__v = __v .+ 1.0
+__v = __v .- 1.0
+__v = __v .* 1.0
+__v = __v ./ 1.0
+
+__m = __m .+ 1.0
+__m = __m .- 1.0
+__m = __m .* 1.0
+__m = __m ./ 1.0
+
+# LinearAlgebra
+
+x = similar(v)
+mul!(x,m,v)
+consistent!(x) |> fetch
+partition(x)
+
+dot(v,x)
+norm(v)
+copy!(x,v)
+
+LinearAlgebra.fillstored!(__m,1.0)
+

--- a/test/BlockPartitionedArraysTests.jl
+++ b/test/BlockPartitionedArraysTests.jl
@@ -58,11 +58,11 @@ mul!(x,_m[1,1],_v)
 @test blocklength(block_range) == 2
 @test blocksize(block_range) == (2,)
 
-# BlockPArray
+# AbstractArray API
 
 __v = similar(v,block_range)
 __m = similar(m,(block_range,block_range))
-fill!(v,1.0)
+fill!(__v,1.0)
 
 __v = __v .+ 1.0
 __v = __v .- 1.0
@@ -74,7 +74,22 @@ __m = __m .- 1.0
 __m = __m .* 1.0
 __m = __m ./ 1.0
 
-# LinearAlgebra
+# PartitionedArrays API
+
+consistent!(__v) |> wait
+t = assemble!(__v)
+assemble!(__m) |> wait
+fetch(t);
+
+PartitionedArrays.to_trivial_partition(m)
+
+local_values(v)
+own_values(v)
+ghost_values(v)
+own_ghost_values(m)
+ghost_own_values(m)
+
+# LinearAlgebra API
 
 x = similar(v)
 mul!(x,m,v)
@@ -89,6 +104,6 @@ LinearAlgebra.fillstored!(__m,1.0)
 
 __v = BlockPVector{Float64,PVector{Vector{Float64}}}(undef,block_range)
 
-m[Block(1,1)]
-m[Block(1),Block(1)]
+maximum(abs,v)
+minimum(abs,v)
 

--- a/test/BlockPartitionedArraysTests.jl
+++ b/test/BlockPartitionedArraysTests.jl
@@ -87,3 +87,8 @@ copy!(x,v)
 
 LinearAlgebra.fillstored!(__m,1.0)
 
+__v = BlockPVector{Float64,PVector{Vector{Float64}}}(undef,block_range)
+
+m[Block(1,1)]
+m[Block(1),Block(1)]
+

--- a/test/BlockSparseMatrixAssemblersTests.jl
+++ b/test/BlockSparseMatrixAssemblersTests.jl
@@ -69,7 +69,16 @@ function _main(n_spaces,mfs,weakform,Ω,dΩ,U,V)
   @test is_same_vector(b1_blocks,b1,Yb,Y)
   @test is_same_matrix(A1_blocks,A1,Xb,X)
 
+  assemble_matrix!(A1_blocks,assem_blocks,bmatdata);
+  assemble_vector!(b1_blocks,assem_blocks,bvecdata);
+  @test is_same_vector(b1_blocks,b1,Yb,Y)
+  @test is_same_matrix(A1_blocks,A1,Xb,X)
+
   A2_blocks, b2_blocks = assemble_matrix_and_vector(assem_blocks,bdata)
+  @test is_same_vector(b2_blocks,b2,Yb,Y)
+  @test is_same_matrix(A2_blocks,A2,Xb,X)
+  
+  assemble_matrix_and_vector!(A2_blocks,b2_blocks,assem_blocks,bdata)
   @test is_same_vector(b2_blocks,b2,Yb,Y)
   @test is_same_matrix(A2_blocks,A2,Xb,X)
 

--- a/test/BlockSparseMatrixAssemblersTests.jl
+++ b/test/BlockSparseMatrixAssemblersTests.jl
@@ -18,17 +18,6 @@ function LinearAlgebra.mul!(y::BlockVector,A::BlockMatrix,x::BlockVector)
   end
 end
 
-function GridapDistributed.change_ghost(
-  x::BlockVector,
-  X::GridapDistributed.DistributedMultiFieldFESpace{<:BlockMultiFieldStyle{NB,SB,P}}) where {NB,SB,P}
-  block_ranges = MultiField.get_block_ranges(NB,SB,P)
-  array = map(block_ranges,blocks(x)) do range, xi
-    Xi = (length(range) == 1) ? X.field_fe_space[range[1]] : MultiFieldFESpace(X.field_fe_space[range])
-    GridapDistributed.change_ghost(xi,Xi.gids)
-  end
-  return mortar(array)
-end
-
 function is_same_vector(x::BlockVector,y::PVector,Ub,U)
   y_fespace = GridapDistributed.change_ghost(y,U.gids)
   x_fespace = GridapDistributed.change_ghost(x,Ub)

--- a/test/BlockSparseMatrixAssemblersTests.jl
+++ b/test/BlockSparseMatrixAssemblersTests.jl
@@ -11,7 +11,7 @@ using GridapDistributed: BlockPVector, BlockPMatrix
 
 function is_same_vector(x::BlockPVector,y::PVector,Ub,U)
   y_fespace = GridapDistributed.change_ghost(y,U.gids)
-  x_fespace = GridapDistributed.change_ghost(x,Ub)
+  x_fespace = GridapDistributed.change_ghost(x,Ub.gids)
 
   res = map(1:num_fields(Ub)) do i
     xi = restrict_to_field(Ub,x_fespace,i)

--- a/test/MultiFieldTests.jl
+++ b/test/MultiFieldTests.jl
@@ -2,11 +2,17 @@ module MultiFieldTests
 
 using Gridap
 using Gridap.FESpaces
+using Gridap.MultiField
 using GridapDistributed
 using PartitionedArrays
 using Test
 
-function main(distribute, parts)
+function l2_error(u1,u2,dΩ)
+  eu = u1 - u2
+  sqrt(sum(∫( eu⋅eu )dΩ))
+end
+
+function main(distribute, parts, mfs)
   ranks  = distribute(LinearIndices((prod(parts),)))
   output = mkpath(joinpath(@__DIR__,"output"))
 
@@ -16,6 +22,7 @@ function main(distribute, parts)
   Ω = Triangulation(model)
 
   k = 2
+  dΩ = Measure(Ω,2*k)
   reffe_u = ReferenceFE(lagrangian,VectorValue{2,Float64},k)
   reffe_p = ReferenceFE(lagrangian,Float64,k-1,space=:P)
 
@@ -29,34 +36,43 @@ function main(distribute, parts)
   U = TrialFESpace(V,u)
   P = TrialFESpace(Q,p)
 
-  VxQ = MultiFieldFESpace([V,Q])
-  UxP = MultiFieldFESpace([U,P]) # This generates again the global numbering
+  VxQ = MultiFieldFESpace([V,Q];style=mfs)
+  UxP = MultiFieldFESpace([U,P];style=mfs) # This generates again the global numbering
   UxP = TrialFESpace([u,p],VxQ) # This reuses the one computed
   @test length(UxP) == 2
 
   uh, ph = interpolate([u,p],UxP)
-  eu = u - uh
-  ep = p - ph
-
-  dΩ = Measure(Ω,2*k)
-  @test sqrt(sum(∫( eu⋅eu )dΩ)) < 1.0e-9
-  @test sqrt(sum(∫( eu⋅eu )dΩ)) < 1.0e-9
+  @test l2_error(u,uh,dΩ) < 1.0e-9
+  @test l2_error(p,ph,dΩ) < 1.0e-9
 
   a((u,p),(v,q)) = ∫( ∇(v)⊙∇(u) - q*(∇⋅u) - (∇⋅v)*p )*dΩ
   l((v,q)) = ∫( v⋅f - q*g )*dΩ
 
   op = AffineFEOperator(a,l,UxP,VxQ)
-  solver = LinearFESolver(BackslashSolver())
-  uh, ph = solve(solver,op)
+  if !isa(mfs,BlockMultiFieldStyle) # BlockMultiFieldStyle does not support BackslashSolver
+    solver = LinearFESolver(BackslashSolver())
+    uh, ph = solve(solver,op)
+    @test l2_error(u,uh,dΩ) < 1.0e-9
+    @test l2_error(p,ph,dΩ) < 1.0e-9
 
-  eu = u - uh
-  ep = p - ph
+    writevtk(Ω,"Ω",nsubcells=10,cellfields=["uh"=>uh,"ph"=>ph])
+  end
 
-  writevtk(Ω,"Ω",nsubcells=10,cellfields=["uh"=>uh,"ph"=>ph])
+  A  = get_matrix(op)
+  xh = interpolate([u,p],UxP)
+  x  = GridapDistributed.change_ghost(get_free_dof_values(xh),axes(A,2))
+  uh1, ph1 = FESpaces.EvaluationFunction(UxP,x)
+  uh2, ph2 = FEFunction(UxP,x)
 
-  @test sqrt(sum(∫( eu⋅eu )dΩ)) < 1.0e-9
-  @test sqrt(sum(∫( eu⋅eu )dΩ)) < 1.0e-9
+  @test l2_error(u,uh1,dΩ) < 1.0e-9
+  @test l2_error(p,ph1,dΩ) < 1.0e-9
+  @test l2_error(u,uh2,dΩ) < 1.0e-9
+  @test l2_error(p,ph2,dΩ) < 1.0e-9
+end
 
+function main(distribute, parts)
+  main(distribute, parts, ConsecutiveMultiFieldStyle())
+  main(distribute, parts, BlockMultiFieldStyle())
 end
 
 end # module

--- a/test/StokesHdivDGTests.jl
+++ b/test/StokesHdivDGTests.jl
@@ -34,84 +34,84 @@ function stokes_solution_2D(μ::Real)
 end
 
 function main(distribute,parts)
-    ranks = distribute(LinearIndices((prod(parts),)))
-    
-    μ = 1.0
-    sol = stokes_solution_2D(μ)
-    u_ref = sol.u
-    f_ref = sol.f
-    σ_ref = sol.σ
+  ranks = distribute(LinearIndices((prod(parts),)))
+  
+  μ = 1.0
+  sol = stokes_solution_2D(μ)
+  u_ref = sol.u
+  f_ref = sol.f
+  σ_ref = sol.σ
 
-    D = 2
-    n = 4
-    domain    = Tuple(repeat([0,1],D))
-    partition = (n,n)
-    model     = CartesianDiscreteModel(ranks,parts,domain,partition)
+  D = 2
+  n = 4
+  domain    = Tuple(repeat([0,1],D))
+  partition = (n,n)
+  model     = CartesianDiscreteModel(ranks,parts,domain,partition)
 
-    labels = get_face_labeling(model)
-    add_tag_from_tags!(labels,"dirichlet",[5,6,7])
-    add_tag_from_tags!(labels,"neumann",[8,])
+  labels = get_face_labeling(model)
+  add_tag_from_tags!(labels,"dirichlet",[5,6,7])
+  add_tag_from_tags!(labels,"neumann",[8,])
 
-    ############################################################################################
-    order = 1
-    reffeᵤ = ReferenceFE(raviart_thomas,Float64,order)
-    V = TestFESpace(model,reffeᵤ,conformity=:HDiv,dirichlet_tags="dirichlet")
-    U = TrialFESpace(V,u_ref)
+  ############################################################################################
+  order = 1
+  reffeᵤ = ReferenceFE(raviart_thomas,Float64,order)
+  V = TestFESpace(model,reffeᵤ,conformity=:HDiv,dirichlet_tags="dirichlet")
+  U = TrialFESpace(V,u_ref)
 
-    reffeₚ = ReferenceFE(lagrangian,Float64,order;space=:P)
-    Q = TestFESpace(model,reffeₚ,conformity=:L2)
-    P = TrialFESpace(Q)
+  reffeₚ = ReferenceFE(lagrangian,Float64,order;space=:P)
+  Q = TestFESpace(model,reffeₚ,conformity=:L2)
+  P = TrialFESpace(Q)
 
-    Y = MultiFieldFESpace([V, Q])
-    X = MultiFieldFESpace([U, P])
+  Y = MultiFieldFESpace([V, Q])
+  X = MultiFieldFESpace([U, P])
 
-    qdegree = 2*order+1
-    Ω   = Triangulation(model)
-    dΩ  = Measure(Ω,qdegree)
+  qdegree = 2*order+1
+  Ω   = Triangulation(model)
+  dΩ  = Measure(Ω,qdegree)
 
-    Γ   = BoundaryTriangulation(model)
-    dΓ  = Measure(Γ,qdegree)
-    n_Γ = get_normal_vector(Γ)
+  Γ   = BoundaryTriangulation(model)
+  dΓ  = Measure(Γ,qdegree)
+  n_Γ = get_normal_vector(Γ)
 
-    Γ_D  = BoundaryTriangulation(model;tags=["dirichlet"])
-    dΓ_D = Measure(Γ_D,qdegree)
-    n_Γ_D = get_normal_vector(Γ_D)
+  Γ_D  = BoundaryTriangulation(model;tags=["dirichlet"])
+  dΓ_D = Measure(Γ_D,qdegree)
+  n_Γ_D = get_normal_vector(Γ_D)
 
-    Γ_N  = BoundaryTriangulation(model;tags="neumann")
-    dΓ_N = Measure(Γ_N,qdegree)
-    n_Γ_N = get_normal_vector(Γ_N)
+  Γ_N  = BoundaryTriangulation(model;tags="neumann")
+  dΓ_N = Measure(Γ_N,qdegree)
+  n_Γ_N = get_normal_vector(Γ_N)
 
-    Λ   = SkeletonTriangulation(model)
-    dΛ  = Measure(Λ,qdegree)
-    n_Λ = get_normal_vector(Λ)
+  Λ   = SkeletonTriangulation(model)
+  dΛ  = Measure(Λ,qdegree)
+  n_Λ = get_normal_vector(Λ)
 
-    h_e    = CellField(map(get_array,local_views(∫(1)dΩ)),Ω)
-    h_e_Λ  = CellField(map(get_array,local_views(∫(1)dΛ)),Λ)
-    h_e_Γ_D = CellField(map(get_array,local_views(∫(1)dΓ_D)),Γ_D)
+  h_e    = CellField(map(get_array,local_views(∫(1)dΩ)),Ω)
+  h_e_Λ  = CellField(map(get_array,local_views(∫(1)dΛ)),Λ)
+  h_e_Γ_D = CellField(map(get_array,local_views(∫(1)dΓ_D)),Γ_D)
 
-    β_U = 50.0
-    Δ_dg(u,v) = ∫(∇(v)⊙∇(u))dΩ - 
-                ∫(jump(v⊗n_Λ)⊙(mean(∇(u))))dΛ -
-                ∫(mean(∇(v))⊙jump(u⊗n_Λ))dΛ - 
-                ∫(v⋅(∇(u)⋅n_Γ_D))dΓ_D - 
-                ∫((∇(v)⋅n_Γ_D)⋅u)dΓ_D
-    rhs((v,q)) = ∫((f_ref⋅v))*dΩ - ∫((∇(v)⋅n_Γ_D)⋅u_ref)dΓ_D + ∫((n_Γ_N⋅σ_ref)⋅v)*dΓ_N
+  β_U = 50.0
+  Δ_dg(u,v) = ∫(∇(v)⊙∇(u))dΩ - 
+              ∫(jump(v⊗n_Λ)⊙(mean(∇(u))))dΛ -
+              ∫(mean(∇(v))⊙jump(u⊗n_Λ))dΛ - 
+              ∫(v⋅(∇(u)⋅n_Γ_D))dΓ_D - 
+              ∫((∇(v)⋅n_Γ_D)⋅u)dΓ_D
+  rhs((v,q)) = ∫((f_ref⋅v))*dΩ - ∫((∇(v)⋅n_Γ_D)⋅u_ref)dΓ_D + ∫((n_Γ_N⋅σ_ref)⋅v)*dΓ_N
 
-    penalty(u,v) = ∫(jump(v⊗n_Λ)⊙((β_U/h_e_Λ*jump(u⊗n_Λ))))dΛ + ∫(v⋅(β_U/h_e_Γ_D*u))dΓ_D
-    penalty_rhs((v,q)) = ∫(v⋅(β_U/h_e_Γ_D*u_ref))dΓ_D
+  penalty(u,v) = ∫(jump(v⊗n_Λ)⊙((β_U/h_e_Λ*jump(u⊗n_Λ))))dΛ + ∫(v⋅(β_U/h_e_Γ_D*u))dΓ_D
+  penalty_rhs((v,q)) = ∫(v⋅(β_U/h_e_Γ_D*u_ref))dΓ_D
 
-    a((u,p),(v,q)) = Δ_dg(u,v) + ∫(-(∇⋅v)*p - q*(∇⋅u))dΩ  + penalty(u,v)  
-    l((v,q)) = rhs((v,q)) - ∫(q*(∇⋅u_ref))dΩ + penalty_rhs((v,q)) 
+  a((u,p),(v,q)) = Δ_dg(u,v) + ∫(-(∇⋅v)*p - q*(∇⋅u))dΩ  + penalty(u,v)  
+  l((v,q)) = rhs((v,q)) - ∫(q*(∇⋅u_ref))dΩ + penalty_rhs((v,q)) 
 
-    op = AffineFEOperator(a,l,X,Y)
-    xh = solve(op)
+  op = AffineFEOperator(a,l,X,Y)
+  xh = solve(op)
 
-    uh, ph = xh
-    err_u = l2_error(Ω,uh,sol.u) 
-    err_p = l2_error(Ω,ph,sol.p)
-    tol = 1.0e-12
-    @test err_u < tol
-    @test err_p < tol
+  uh, ph = xh
+  err_u = l2_error(Ω,uh,sol.u) 
+  err_p = l2_error(Ω,ph,sol.p)
+  tol = 1.0e-12
+  @test err_u < tol
+  @test err_p < tol
 end
 
 end # module


### PR DESCRIPTION
Todo/Done:

- [x] Merge functionalities of `consistent_local_views` and `change_ghost`. Expand functionality of `change_ghost`. 
- [x] Add possibility to use `OwnAndGhostVector` as vector partition of resulting `PVector`s, as a way to reduce memory copying when transferring between FESpace and linear system layouts. 
- [x] Implement `BlockPArray <: AbstractBlockArray`, a new type that behaves as a `BlockArray{PArray}` and which fulfills the APIs of both `PArray` and `AbstractBlockArray`. This will get rid of the type piracy we have been using up to now and gets rid of some of the issues we are having (mainly, the fact that `BlockArray` expects its blocks to be indexable). 
- [x] `MultiFieldFESpace{<:BlockMultiFieldStyle}` now has a `BlockPRange` as gids, which makes the fespace dof vector be of type `BlockPVector`. This is necessary to create consistency between fespace and system vectors, which in turn avoids memory allocations/copies when transferring between FESpace and linear system layouts. 

To Think:
- Now `BlockPArray` constructors work with `BlockPRange`s, which is inconsistent with PartitionedArrays. Should we be trying to be coherent? How can we do it well for dispatching? 

Left for another PR: 
- Implement a new mechanism that allows the user to skip `PRange` ghost-related optimisations while assembling the system matrix. This will create linear systems which ghost layout is compatible with the original FESpace, avoiding copying data when transferring between FESpace and linear system layouts. 