### PR TITLE
Redistribute for MultiField

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Added redistribution for MultiFieldFESpaces. Since PR [#140](https://github.com/gridap/GridapDistributed.jl/pull/140).
+
 ## [0.3.5] - 2023-12-04
 
 ### Added

--- a/src/Adaptivity.jl
+++ b/src/Adaptivity.jl
@@ -260,11 +260,64 @@ function _get_cell_dof_ids_inner_space(s::TrialFESpace)
   _get_cell_dof_ids_inner_space(s.space)
 end
 
-function get_redistribute_free_values_cache(fv_new::Union{PVector,Nothing},
-                                            Uh_new::Union{DistributedSingleFieldFESpace,Nothing},
-                                            fv_old::Union{PVector,Nothing},
-                                            dv_old::Union{AbstractArray,Nothing},
-                                            Uh_old::Union{DistributedSingleFieldFESpace,Nothing},
+function redistribute_fe_function(uh_old::Union{DistributedSingleFieldFEFunction,Nothing},
+                                  Uh_new::Union{DistributedSingleFieldFESpace,Nothing},
+                                  model_new,
+                                  glue::RedistributeGlue;
+                                  reverse=false)
+
+  old_parts, new_parts = get_old_and_new_parts(glue,Val(reverse))
+  cell_dof_values_old  = i_am_in(old_parts) ? map(get_cell_dof_values,local_views(uh_old)) : nothing
+  cell_dof_ids_new     = i_am_in(new_parts) ? map(_get_cell_dof_ids_inner_space,local_views(Uh_new)) : nothing
+  cell_dof_values_new  = redistribute_cell_dofs(cell_dof_values_old,cell_dof_ids_new,model_new,glue;reverse=reverse)
+
+  # Assemble the new FEFunction
+  if i_am_in(new_parts)
+    free_values, dirichlet_values = Gridap.FESpaces.gather_free_and_dirichlet_values(Uh_new,cell_dof_values_new)
+    free_values = PVector(free_values,partition(Uh_new.gids))
+    uh_new = FEFunction(Uh_new,free_values,dirichlet_values)
+    return uh_new
+  else
+    return nothing
+  end
+end
+
+_get_fe_type(U::DistributedSingleFieldFESpace,V) = DistributedSingleFieldFESpace
+_get_fe_type(U,V::DistributedSingleFieldFESpace) = DistributedSingleFieldFESpace
+_get_fe_type(U::DistributedMultiFieldFESpace,V)  = DistributedMultiFieldFESpace
+_get_fe_type(U,V::DistributedMultiFieldFESpace)  = DistributedMultiFieldFESpace
+
+function redistribute_free_values(fv_new::Union{PVector,Nothing},
+                                  Uh_new::Union{DistributedSingleFieldFESpace,DistributedMultiFieldFESpace,Nothing},
+                                  fv_old::Union{PVector,Nothing},
+                                  dv_old::Union{AbstractArray,Nothing},
+                                  Uh_old::Union{DistributedSingleFieldFESpace,DistributedMultiFieldFESpace,Nothing},
+                                  model_new,
+                                  glue::RedistributeGlue;
+                                  reverse=false)
+
+  caches = get_redistribute_free_values_cache(fv_new,Uh_new,fv_old,dv_old,Uh_old,model_new,glue;reverse=reverse)
+  return redistribute_free_values!(caches,fv_new,Uh_new,fv_old,dv_old,Uh_old,model_new,glue;reverse=reverse)
+end
+
+function get_redistribute_free_values_cache(fv_new,
+                                            Uh_new,
+                                            fv_old,
+                                            dv_old,
+                                            Uh_old,
+                                            model_new,
+                                            glue::RedistributeGlue;
+                                            reverse=false)
+  T = _get_fe_type(Uh_new,Uh_old)
+  get_redistribute_free_values_cache(T,fv_new,Uh_new,fv_old,dv_old,Uh_old,model_new,glue;reverse=reverse)
+end
+
+function get_redistribute_free_values_cache(::Type{DistributedSingleFieldFESpace},
+                                            fv_new,
+                                            Uh_new,
+                                            fv_old,
+                                            dv_old,
+                                            Uh_old,
                                             model_new,
                                             glue::RedistributeGlue;
                                             reverse=false)
@@ -275,20 +328,59 @@ function get_redistribute_free_values_cache(fv_new::Union{PVector,Nothing},
   return caches
 end
 
-function redistribute_free_values(fv_new::Union{PVector,Nothing},
-                                  Uh_new::Union{DistributedSingleFieldFESpace,Nothing},
-                                  fv_old::Union{PVector,Nothing},
-                                  dv_old::Union{AbstractArray,Nothing},
-                                  Uh_old::Union{DistributedSingleFieldFESpace,Nothing},
-                                  model_new,
-                                  glue::RedistributeGlue;
-                                  reverse=false)
+function get_redistribute_free_values_cache(::Type{DistributedMultiFieldFESpace},
+                                            fv_new,
+                                            Uh_new,
+                                            fv_old,
+                                            dv_old,
+                                            Uh_old,
+                                            model_new,
+                                            glue::RedistributeGlue;
+                                            reverse=false)
+  old_parts, new_parts = get_old_and_new_parts(glue,Val(reverse))
 
-  caches = get_redistribute_free_values_cache(fv_new,Uh_new,fv_old,dv_old,Uh_old,model_new,glue;reverse=reverse)
-  return redistribute_free_values!(caches,fv_new,Uh_new,fv_old,dv_old,Uh_old,model_new,glue;reverse=reverse)
+  if i_am_in(old_parts)
+    Uh_old_i = Uh_old.field_fe_space
+    fv_old_i = map(i->restrict_to_field(Uh_old,fv_old,i),1:num_fields(Uh_old))
+    dv_old_i = dv_old
+  else
+    nfields = num_fields(Uh_new) # The other is not Nothing
+    Uh_old_i = [Nothing for i = 1:nfields]
+    fv_old_i = [Nothing for i = 1:nfields]
+    dv_old_i = [Nothing for i = 1:nfields]
+  end
+
+  if i_am_in(new_parts)
+    Uh_new_i = Uh_new.field_fe_space
+    fv_new_i = map(i->restrict_to_field(Uh_new,fv_new,i),1:num_fields(Uh_new))
+  else
+    nfields = num_fields(Uh_old) # The other is not Nothing
+    Uh_new_i = [Nothing for i = 1:nfields]
+    fv_new_i = [Nothing for i = 1:nfields]
+  end
+
+  caches = map(Uh_new_i,Uh_old_i,fv_new_i,fv_old_i,dv_old_i) do Uh_new_i,Uh_old_i,fv_new_i,fv_old_i,dv_old_i
+    get_redistribute_free_values_cache(DistributedSingleFieldFESpace,fv_new_i,Uh_new_i,fv_old_i,dv_old_i,Uh_old_i,model_new,glue;reverse=reverse)
+  end
+
+  return caches
 end
 
 function redistribute_free_values!(caches,
+                                   fv_new::Union{PVector,Nothing},
+                                   Uh_new::Union{DistributedSingleFieldFESpace,Nothing},
+                                   fv_old::Union{PVector,Nothing},
+                                   dv_old::Union{AbstractArray,Nothing},
+                                   Uh_old::Union{DistributedSingleFieldFESpace,Nothing},
+                                   model_new,
+                                   glue::RedistributeGlue;
+                                   reverse=false)
+  T = _get_fe_type(Uh_new,Uh_old)
+  redistribute_free_values!(T,caches,fv_new,Uh_new,fv_old,dv_old,Uh_old,model_new,glue;reverse=reverse)
+end
+
+function redistribute_free_values!(::Type{DistributedSingleFieldFESpace},
+                                   caches,
                                    fv_new::Union{PVector,Nothing},
                                    Uh_new::Union{DistributedSingleFieldFESpace,Nothing},
                                    fv_old::Union{PVector,Nothing},
@@ -310,24 +402,40 @@ function redistribute_free_values!(caches,
   return fv_new
 end
 
-function redistribute_fe_function(uh_old::Union{DistributedSingleFieldFEFunction,Nothing},
-                                  Uh_new::Union{DistributedSingleFieldFESpace,Nothing},
-                                  model_new,
-                                  glue::RedistributeGlue;
-                                  reverse=false)
+function redistribute_free_values!(::Type{DistributedMultiFieldFESpace},
+                                   caches,
+                                   fv_new::Union{PVector,Nothing},
+                                   Uh_new::Union{DistributedSingleFieldFESpace,Nothing},
+                                   fv_old::Union{PVector,Nothing},
+                                   dv_old::Union{AbstractArray,Nothing},
+                                   Uh_old::Union{DistributedSingleFieldFESpace,Nothing},
+                                   model_new,
+                                   glue::RedistributeGlue;
+                                   reverse=false)
 
   old_parts, new_parts = get_old_and_new_parts(glue,Val(reverse))
-  cell_dof_values_old  = i_am_in(old_parts) ? map(get_cell_dof_values,local_views(uh_old)) : nothing
-  cell_dof_ids_new     = i_am_in(new_parts) ? map(_get_cell_dof_ids_inner_space,local_views(Uh_new)) : nothing
-  cell_dof_values_new  = redistribute_cell_dofs(cell_dof_values_old,cell_dof_ids_new,model_new,glue;reverse=reverse)
 
-  # Assemble the new FEFunction
-  if i_am_in(new_parts)
-    free_values, dirichlet_values = Gridap.FESpaces.gather_free_and_dirichlet_values(Uh_new,cell_dof_values_new)
-    free_values = PVector(free_values,partition(Uh_new.gids))
-    uh_new = FEFunction(Uh_new,free_values,dirichlet_values)
-    return uh_new
+  if i_am_in(old_parts)
+    Uh_old_i = Uh_old.field_fe_space
+    fv_old_i = map(i->restrict_to_field(Uh_old,fv_old,i),1:num_fields(Uh_old))
+    dv_old_i = dv_old
   else
-    return nothing
+    nfields = num_fields(Uh_new) # The other is not Nothing
+    Uh_old_i = [Nothing for i = 1:nfields]
+    fv_old_i = [Nothing for i = 1:nfields]
+    dv_old_i = [Nothing for i = 1:nfields]
+  end
+
+  if i_am_in(new_parts)
+    Uh_new_i = Uh_new.field_fe_space
+    fv_new_i = map(i->restrict_to_field(Uh_new,fv_new,i),1:num_fields(Uh_new))
+  else
+    nfields = num_fields(Uh_old) # The other is not Nothing
+    Uh_new_i = [Nothing for i = 1:nfields]
+    fv_new_i = [Nothing for i = 1:nfields]
+  end
+
+  map!(Uh_new_i,Uh_old_i,fv_new_i,fv_old_i,dv_old_i,caches) do Uh_new_i,Uh_old_i,fv_new_i,fv_old_i,dv_old_i,caches
+    redistribute_free_values!(DistributedSingleFieldFESpace,caches,fv_new_i,Uh_new_i,fv_old_i,dv_old_i,Uh_old_i,model_new,glue;reverse=reverse)
   end
 end

--- a/src/MultiField.jl
+++ b/src/MultiField.jl
@@ -71,6 +71,10 @@ function MultiField.restrict_to_field(
   PVector(values,partition(gids))
 end
 
+function FESpaces.zero_dirichlet_values(f::DistributedMultiFieldFESpace)
+  map(zero_dirichlet_values,f.field_fe_space)
+end
+
 function FESpaces.FEFunction(
   f::DistributedMultiFieldFESpace,x::AbstractVector,isconsistent=false)
   free_values  = change_ghost(x,f.gids;is_consistent=isconsistent,make_consistent=true)

--- a/test/AdaptivityMultiFieldTests.jl
+++ b/test/AdaptivityMultiFieldTests.jl
@@ -1,0 +1,227 @@
+module AdaptivityMultiFieldTests
+using Test
+
+using Gridap
+using Gridap.Geometry
+using Gridap.Adaptivity
+using Gridap.FESpaces
+
+using MPI
+using GridapDistributed
+using PartitionedArrays
+
+using GridapDistributed: i_am_in, generate_subparts
+using GridapDistributed: find_local_to_local_map
+using GridapDistributed: DistributedAdaptedDiscreteModel
+using GridapDistributed: RedistributeGlue, redistribute_cell_dofs, redistribute_fe_function, redistribute_free_values
+
+function are_equal(a1::MPIArray,a2::MPIArray)
+  same = map(a1,a2) do a1,a2
+    a1 ≈ a2
+  end
+  return reduce(&,same,init=true)
+end
+
+function are_equal(a1::PVector,a2::PVector)
+  are_equal(own_values(a1),own_values(a2))
+end
+
+function DistributedAdaptivityGlue(serial_glue,parent,child)
+  glue = map(partition(get_cell_gids(parent)),partition(get_cell_gids(child))) do parent_gids, child_gids
+    old_g2l = global_to_local(parent_gids)
+    old_l2g = local_to_global(parent_gids)
+    new_l2g = local_to_global(child_gids)
+
+    n2o_cell_map  = lazy_map(Reindex(old_g2l),serial_glue.n2o_faces_map[3][new_l2g])
+    n2o_faces_map = [Int64[],Int64[],collect(n2o_cell_map)]
+    n2o_cell_to_child_id = serial_glue.n2o_cell_to_child_id[new_l2g]
+    rrules = serial_glue.refinement_rules[old_l2g]
+    AdaptivityGlue(n2o_faces_map,n2o_cell_to_child_id,rrules)
+  end
+  return glue
+end
+
+function get_redistribute_glue(old_parts,new_parts::DebugArray,old_cell_to_part,new_cell_to_part,model,redist_model)
+  parts_rcv,parts_snd,lids_rcv,lids_snd,old2new,new2old = 
+  map(new_parts,partition(get_cell_gids(redist_model))) do p,new_partition
+    old_new_cell_to_part = collect(zip(old_cell_to_part,new_cell_to_part))
+    gids_rcv = findall(x->x[1]!=p && x[2]==p, old_new_cell_to_part)
+    gids_snd = findall(x->x[1]==p && x[2]!=p, old_new_cell_to_part)
+
+    parts_rcv = unique(old_cell_to_part[gids_rcv])
+    parts_snd = unique(new_cell_to_part[gids_snd])
+
+    gids_rcv_by_part = [filter(x -> old_cell_to_part[x] == nbor, gids_rcv) for nbor in parts_rcv]
+    gids_snd_by_part = [filter(x -> new_cell_to_part[x] == nbor, gids_snd) for nbor in parts_snd]
+
+    if p ∈ old_parts.items
+      old_partition = partition(get_cell_gids(model)).items[p]
+      lids_rcv = map(gids -> lazy_map(Reindex(global_to_local(new_partition)),gids),gids_rcv_by_part)
+      lids_snd = map(gids -> lazy_map(Reindex(global_to_local(old_partition)),gids),gids_snd_by_part)
+      old2new = replace(find_local_to_local_map(old_partition,new_partition), -1 => 0)
+      new2old = replace(find_local_to_local_map(new_partition,old_partition), -1 => 0)
+    else
+      lids_rcv = map(gids -> lazy_map(Reindex(global_to_local(new_partition)),gids),gids_rcv_by_part)
+      lids_snd = map(gids -> fill(Int32(0),length(gids)),gids_snd_by_part)
+      old2new = Int[]
+      new2old = fill(0,length(findall(x -> x == p,new_cell_to_part)))
+    end
+
+    return parts_rcv,parts_snd,JaggedArray(lids_rcv),JaggedArray(lids_snd),old2new,new2old
+  end |> tuple_of_arrays
+
+  return RedistributeGlue(new_parts,old_parts,parts_rcv,parts_snd,lids_rcv,lids_snd,old2new,new2old)
+end
+
+function get_redistribute_glue(old_parts,new_parts::MPIArray,old_cell_to_part,new_cell_to_part,model,redist_model)
+  parts_rcv,parts_snd,lids_rcv,lids_snd,old2new,new2old = 
+  map(new_parts,partition(get_cell_gids(redist_model))) do p,new_partition
+    old_new_cell_to_part = collect(zip(old_cell_to_part,new_cell_to_part))
+    gids_rcv = findall(x->x[1]!=p && x[2]==p, old_new_cell_to_part)
+    gids_snd = findall(x->x[1]==p && x[2]!=p, old_new_cell_to_part)
+
+    parts_rcv = unique(old_cell_to_part[gids_rcv])
+    parts_snd = unique(new_cell_to_part[gids_snd])
+
+    gids_rcv_by_part = [filter(x -> old_cell_to_part[x] == nbor, gids_rcv) for nbor in parts_rcv]
+    gids_snd_by_part = [filter(x -> new_cell_to_part[x] == nbor, gids_snd) for nbor in parts_snd]
+
+    if i_am_in(old_parts)
+      old_partition = PartitionedArrays.getany(partition(get_cell_gids(model)))
+      lids_rcv = map(gids -> lazy_map(Reindex(global_to_local(new_partition)),gids),gids_rcv_by_part)
+      lids_snd = map(gids -> lazy_map(Reindex(global_to_local(old_partition)),gids),gids_snd_by_part)
+      old2new = replace(find_local_to_local_map(old_partition,new_partition), -1 => 0)
+      new2old = replace(find_local_to_local_map(new_partition,old_partition), -1 => 0)
+    else
+      lids_rcv = map(gids -> lazy_map(Reindex(global_to_local(new_partition)),gids),gids_rcv_by_part)
+      lids_snd = map(gids -> fill(Int32(0),length(gids)),gids_snd_by_part)
+      old2new = Int[]
+      new2old = fill(0,length(findall(x -> x == p,new_cell_to_part)))
+    end
+
+    return parts_rcv,parts_snd,JaggedArray(lids_rcv),JaggedArray(lids_snd),old2new,new2old
+  end |> tuple_of_arrays
+
+  return RedistributeGlue(new_parts,old_parts,parts_rcv,parts_snd,lids_rcv,lids_snd,old2new,new2old)
+end
+
+function test_redistribution(coarse_ranks, fine_ranks, model, redist_model, redist_glue)
+  sol(x) = sum(x)
+  reffe  = ReferenceFE(lagrangian,Float64,1)
+
+  if i_am_in(coarse_ranks)
+    space = MultiFieldFESpace([FESpace(model,reffe),FESpace(model,reffe)])
+    u = interpolate([sol,sol],space)
+    free_values = get_free_dof_values(u)
+    dir_values = zero_dirichlet_values(space)
+  else
+    space = nothing; u = nothing; free_values = nothing; dir_values = nothing;
+  end
+
+  redist_space = MultiFieldFESpace([FESpace(redist_model,reffe),FESpace(redist_model,reffe)])
+  redist_u = interpolate([sol,sol],redist_space)
+  redist_free_values = get_free_dof_values(redist_u)
+  redist_dir_values = zero_dirichlet_values(redist_space)
+
+  # Redistribute free values, both ways
+  tmp_free_values = copy(redist_free_values)
+  redistribute_free_values(tmp_free_values,redist_space,free_values,dir_values,space,redist_model,redist_glue)
+  @test are_equal(redist_free_values,tmp_free_values)
+
+  tmp_free_values = i_am_in(coarse_ranks) ? copy(free_values) : nothing
+  redistribute_free_values(tmp_free_values,space,redist_free_values,redist_dir_values,redist_space,model,redist_glue;reverse=true)
+  if i_am_in(coarse_ranks)
+    @test are_equal(free_values,tmp_free_values)
+  end
+
+  return true
+end
+
+function test_adaptivity(ranks,cmodel,fmodel,glue)
+  if i_am_in(ranks)
+    sol(x) = sum(x)
+    reffe  = ReferenceFE(lagrangian,Float64,1)
+    amodel = DistributedAdaptedDiscreteModel(fmodel,cmodel,glue)
+
+    Ωf  = Triangulation(amodel)
+    dΩf = Measure(Ωf,2)
+    Vf  = FESpace(amodel,reffe)
+    Uf  = TrialFESpace(Vf)
+    Xf  = MultiFieldFESpace([Uf,Uf])
+    Yf  = MultiFieldFESpace([Vf,Vf])
+    uh_fine = interpolate([sol,sol],Xf)
+
+    Ωc  = Triangulation(cmodel)
+    dΩc = Measure(Ωc,2)
+    Vc  = FESpace(cmodel,reffe)
+    Uc  = TrialFESpace(Vc)
+    Xc  = MultiFieldFESpace([Uc,Uc])
+    Yc  = MultiFieldFESpace([Vc,Vc])
+    uh_coarse = interpolate([sol,sol],Xc)
+
+    dΩcf = Measure(Ωc,Ωf,2)
+
+    # Coarse to Fine projection
+    af((u1,u2),(v1,v2)) = ∫(u1⋅v1 + u2⋅v2)*dΩf
+    lf((v1,v2)) = ∫(uh_coarse[1]*v1 + uh_coarse[2]*v2)*dΩf
+    op = AffineFEOperator(af,lf,Xf,Yf)
+    uh_coarse_to_fine = solve(op)
+
+    eh1  = uh_fine[1] - uh_coarse_to_fine[1]
+    eh2  = uh_fine[2] - uh_coarse_to_fine[2]
+    @test sum(∫(eh1⋅eh1 + eh2⋅eh2)*dΩf) < 1e-8
+
+    # Fine to Coarse projection
+    ac((u1,u2),(v1,v2)) = ∫(u1⋅v1 + u2⋅v2)*dΩc
+    lc((v1,v2)) = ∫(uh_fine[1]*v1 + uh_fine[2]*v2)*dΩcf
+    op = AffineFEOperator(ac,lc,Xc,Yc)
+    uh_fine_to_coarse = solve(op)
+
+    eh1  = uh_coarse[1] - uh_fine_to_coarse[1]
+    eh2  = uh_coarse[2] - uh_fine_to_coarse[2]
+    @test sum(∫(eh1⋅eh1 + eh2⋅eh2)*dΩc) < 1e-8
+  end
+  return true
+end
+
+############################################################################################
+
+function main(distribute)
+  fine_ranks = distribute(LinearIndices((4,)))
+  coarse_ranks = generate_subparts(fine_ranks,2)
+
+  # Create models and glues 
+  serial_parent = UnstructuredDiscreteModel(CartesianDiscreteModel((0,1,0,1),(4,4)))
+  serial_child  = refine(serial_parent)
+  serial_rglue  = get_adaptivity_glue(serial_child)
+
+  parent_cell_to_part = [1,1,1,1,1,1,1,1,2,2,2,2,2,2,2,2]
+  child_cell_to_part  = lazy_map(Reindex(parent_cell_to_part),serial_rglue.n2o_faces_map[3])
+  if i_am_in(coarse_ranks)
+    parent = DiscreteModel(coarse_ranks,serial_parent,parent_cell_to_part)
+    child  = DiscreteModel(coarse_ranks,serial_child,child_cell_to_part)
+    coarse_adaptivity_glue = DistributedAdaptivityGlue(serial_rglue,parent,child)
+  else
+    parent = nothing; child  = nothing; coarse_adaptivity_glue = nothing
+  end
+
+  redist_parent_cell_to_part = [1,1,2,2,1,1,2,2,3,3,4,4,3,3,4,4]
+  redist_parent = DiscreteModel(fine_ranks,serial_parent,redist_parent_cell_to_part)
+  redist_glue_parent = get_redistribute_glue(coarse_ranks,fine_ranks,parent_cell_to_part,redist_parent_cell_to_part,parent,redist_parent);
+
+  redist_child_cell_to_part = lazy_map(Reindex(redist_parent_cell_to_part),serial_rglue.n2o_faces_map[3])
+  redist_child = DiscreteModel(fine_ranks,serial_child,redist_child_cell_to_part)
+  fine_adaptivity_glue = DistributedAdaptivityGlue(serial_rglue,redist_parent,redist_child)
+  redist_glue_child = get_redistribute_glue(coarse_ranks,fine_ranks,child_cell_to_part,redist_child_cell_to_part,child,redist_child);
+
+  # Tests
+  test_redistribution(coarse_ranks,fine_ranks,parent,redist_parent,redist_glue_parent)
+  test_redistribution(coarse_ranks,fine_ranks,child,redist_child,redist_glue_child)
+
+  test_adaptivity(coarse_ranks,parent,child,coarse_adaptivity_glue)
+  test_adaptivity(fine_ranks,redist_parent,redist_child,fine_adaptivity_glue)
+
+  return
+end
+
+end # module AdaptivityMultiFieldTests

--- a/test/TestApp/src/TestApp.jl
+++ b/test/TestApp/src/TestApp.jl
@@ -12,5 +12,6 @@ module TestApp
   include("../../HeatEquationTests.jl")
   include("../../StokesOpenBoundaryTests.jl")
   include("../../AdaptivityTests.jl")
+  include("../../AdaptivityMultiFieldTests.jl")
   include("../../BlockSparseMatrixAssemblersTests.jl")
 end

--- a/test/mpi/runtests_np4_body.jl
+++ b/test/mpi/runtests_np4_body.jl
@@ -42,6 +42,7 @@ function all_tests(distribute,parts)
 
   if prod(parts) == 4
     TestApp.AdaptivityTests.main(distribute)
+    TestApp.AdaptivityMultiFieldTests.main(distribute)
     PArrays.toc!(t,"Adaptivity")
   end
 


### PR DESCRIPTION
Redistribution for MultiFieldFESpaces... 
The current implementation loops through the different FESpaces, so it's definitely not the best. I believe the most efficient way of tackling this in general is to redistribute information dof-wise, not cell-wise. But this will come later...