### PR TITLE
Compatibility with 32-bit machines

### DIFF
--- a/.github/workflows/ci_x86.yml
+++ b/.github/workflows/ci_x86.yml
@@ -1,0 +1,76 @@
+name: CI_X86
+on: 
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  SequentialTests:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.9'
+        os:
+          - ubuntu-latest
+        arch:
+          - x86
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@v1
+      - run: julia --project=. -e 'using Pkg; Pkg.instantiate()'
+      - run: julia --project=. --color=yes --check-bounds=yes test/sequential/runtests.jl
+  MPITests:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.9'
+        os:
+          - ubuntu-latest
+        arch:
+          - x86
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      #- uses: julia-actions/julia-buildpkg@v1
+      - run: |
+          julia --project=test/TestApp/ -e '
+            using Pkg
+            Pkg.develop(PackageSpec(path=pwd()))
+            Pkg.instantiate()'
+      - run: cd test/TestApp/compile; ./compile.sh 
+      - run: julia --project=test/TestApp/ --color=yes --check-bounds=yes test/mpi/runtests.jl test/TestApp/compile/TestApp.so

--- a/src/Algebra.jl
+++ b/src/Algebra.jl
@@ -1158,7 +1158,7 @@ function _setup_prange_without_ghosts(dofs_gids_prange::PRange)
   indices = map(partition(dofs_gids_prange)) do dofs_indices 
     owner = part_id(dofs_indices)
     own_indices = OwnIndices(ngdofs,owner,own_to_global(dofs_indices))
-    ghost_indices = GhostIndices(ngdofs,Int64[],Int32[])
+    ghost_indices = GhostIndices(ngdofs,Int[],Int32[])
     OwnAndGhostIndices(own_indices,ghost_indices)
   end
   return PRange(indices)
@@ -1197,8 +1197,8 @@ function _setup_prange_with_ghosts(dofs_gids_prange::PRange,gids,owners)
   gids_ghost_to_global, gids_ghost_to_owner = map(
     gids,owners,dofs_gids_partition) do gids, owners, indices
     ghost_touched   = Dict{Int,Bool}()
-    ghost_to_global = Int64[] 
-    ghost_to_owner  = Int64[]
+    ghost_to_global = Int[]
+    ghost_to_owner  = Int[]
     me = part_id(indices)
     for (j,jo) in zip(gids,owners)
       if jo != me

--- a/test/AdaptivityMultiFieldTests.jl
+++ b/test/AdaptivityMultiFieldTests.jl
@@ -33,7 +33,7 @@ function DistributedAdaptivityGlue(serial_glue,parent,child)
     new_l2g = local_to_global(child_gids)
 
     n2o_cell_map  = lazy_map(Reindex(old_g2l),serial_glue.n2o_faces_map[3][new_l2g])
-    n2o_faces_map = [Int64[],Int64[],collect(n2o_cell_map)]
+    n2o_faces_map = [Int[],Int[],collect(n2o_cell_map)]
     n2o_cell_to_child_id = serial_glue.n2o_cell_to_child_id[new_l2g]
     rrules = serial_glue.refinement_rules[old_l2g]
     AdaptivityGlue(n2o_faces_map,n2o_cell_to_child_id,rrules)

--- a/test/AdaptivityTests.jl
+++ b/test/AdaptivityTests.jl
@@ -33,7 +33,7 @@ function DistributedAdaptivityGlue(serial_glue,parent,child)
     new_l2g = local_to_global(child_gids)
 
     n2o_cell_map  = lazy_map(Reindex(old_g2l),serial_glue.n2o_faces_map[3][new_l2g])
-    n2o_faces_map = [Int64[],Int64[],collect(n2o_cell_map)]
+    n2o_faces_map = [Int[],Int[],collect(n2o_cell_map)]
     n2o_cell_to_child_id = serial_glue.n2o_cell_to_child_id[new_l2g]
     rrules = serial_glue.refinement_rules[old_l2g]
     AdaptivityGlue(n2o_faces_map,n2o_cell_to_child_id,rrules)

--- a/test/BlockPartitionedArraysTests.jl
+++ b/test/BlockPartitionedArraysTests.jl
@@ -99,7 +99,7 @@ copy!(x,v)
 LinearAlgebra.fillstored!(__m,1.0)
 
 __v = BlockPVector{Vector{Float64}}(undef,block_range)
-#__m = BlockPMatrix{SparseMatrixCSC{Float64,Int64}}(undef,block_range,block_range)
+#__m = BlockPMatrix{SparseMatrixCSC{Float64,Int}}(undef,block_range,block_range)
 
 maximum(abs,v)
 minimum(abs,v)


### PR DESCRIPTION
@santiagobadia 

I have added compatibility with 32-bit machines. This compatibility inherits from Gridap. It allows keeping 32-bit tests in repositories depending on GridapDistributed, e.g., GridapEmbeded.