### PR TITLE
Let pass kwargs to distributed measures

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Added keyword arguments in the signature of the constructor of `DistributedMeasure`. Since PR[#150](https://github.com/gridap/GridapDistributed.jl/pull/150).
+
 ## [0.4.2] 2024-07-4
 
 ### Added

--- a/src/CellData.jl
+++ b/src/CellData.jl
@@ -197,9 +197,9 @@ end
 
 local_views(a::DistributedMeasure) = a.measures
 
-function CellData.Measure(t::DistributedTriangulation,args...)
+function CellData.Measure(t::DistributedTriangulation,args...;kwargs...)
   measures = map(t.trians) do trian
-    Measure(trian,args...)
+    Measure(trian,args...;kwargs...)
   end
   DistributedMeasure(measures,t)
 end


### PR DESCRIPTION
This little PR lets one pass keyword arguments for measures.

It is needed to use GridapEmbedded's algoim quadratures in distributed workflows.