### PR TITLE
Bugfix: writevtk with empty parts

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed bug in writevtk when dealing with empty processors. Since PR[#158](https://github.com/gridap/GridapDistributed.jl/pull/158).
+
 ## [0.4.4] 2024-08-14
 
 ### Added

--- a/test/TestApp/src/TestApp.jl
+++ b/test/TestApp/src/TestApp.jl
@@ -17,4 +17,5 @@ module TestApp
   include("../../AdaptivityUnstructuredTests.jl")
   include("../../AdaptivityMultiFieldTests.jl")
   include("../../BlockSparseMatrixAssemblersTests.jl")
+  include("../../VisualizationTests.jl")
 end

--- a/test/VisualizationTests.jl
+++ b/test/VisualizationTests.jl
@@ -1,0 +1,31 @@
+module VisualizationTests
+
+using Gridap, GridapDistributed, PartitionedArrays
+
+function half_empty_trian(ranks,model)
+  cell_ids = get_cell_gids(model)
+  trians = map(ranks,local_views(model),partition(cell_ids)) do rank, model, ids
+    cell_mask = zeros(Bool, num_cells(model))
+    if rank ∈ (3,4)
+      cell_mask[own_to_local(ids)] .= true
+    end
+    Triangulation(model,cell_mask)
+  end
+  GridapDistributed.DistributedTriangulation(trians,model)
+end
+
+function main(distribute,parts)
+  ranks = distribute(LinearIndices((prod(parts),)))
+
+  model = CartesianDiscreteModel(ranks,parts,(0,1,0,1),(8,8))
+  V = FESpace(model, ReferenceFE(lagrangian,Float64,1))
+  uh = interpolate(x -> x[1]+x[2], V)
+
+  t1 = Triangulation(model)
+  writevtk(t1,"output/t1",cellfields=["uh" => uh]) 
+
+  t2 = half_empty_trian(ranks,model)
+  writevtk(t2,"output/t2",cellfields=["uh" => uh])
+end
+
+end # module

--- a/test/mpi/runtests_np4_body.jl
+++ b/test/mpi/runtests_np4_body.jl
@@ -54,5 +54,10 @@ function all_tests(distribute,parts)
   TestApp.BlockSparseMatrixAssemblersTests.main(distribute,parts)
   PArrays.toc!(t,"BlockSparseMatrixAssemblers")
 
+  if prod(parts) == 4
+    TestApp.VisualizationTests.main(distribute,parts)
+    PArrays.toc!(t,"Visualization")
+  end
+
   display(t)
 end


### PR DESCRIPTION
This is a PR to solve a quite niche issue that happens when we try to write out a pvtk file where some of the files are empty, i.e when the Triangulation is empty in some processors. 

In that case, we would still be creating a file per processor and end up with some empty files. Notably, these empty files would be missing the tags for the fields we wanted to export. This breaks the paraview import, making the files unusable. 

As a solution, I filter out the processors with empty Triangulations and remap the processor ids to only create as many files as nonempty processors. 

Edit: This has now been tested with fairly complicated meshes and more than 100 processors, and everything seems to work fine. The only question then is if this is the best approach or not. 