### PR TITLE
Bugfix in _add_distributed_constraint

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.15] - 2026-03-23
+
+### Fixed
+
+- Fixed `_add_distributed_constraint` in the case where the underlying `FESpace` has multiple (different) reffes. Since PR[#201](https://github.com/gridap/GridapDistributed.jl/pull/201).
+
 ## [0.4.14] - 2026-03-20
 
 ### Changed 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GridapDistributed"
 uuid = "f9701e48-63b3-45aa-9a63-9bc6c271f355"
 authors = ["S. Badia <santiago.badia@monash.edu>", "A. F. Martin <alberto.f.martin@anu.edu.au>", "F. Verdugo <f.verdugo.rojano@vu.nl>"]
-version = "0.4.14"
+version = "0.4.15"
 
 [deps]
 BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"

--- a/src/FESpaces.jl
+++ b/src/FESpaces.jl
@@ -633,6 +633,7 @@ end
 function _add_distributed_constraint(
   F::DistributedFESpace,reffe::ReferenceFE,constraint
 )
+  isnothing(constraint) && return F
   order = get_order(reffe)
   _add_distributed_constraint(F,order,constraint)
 end
@@ -640,6 +641,7 @@ end
 function _add_distributed_constraint(
   F::DistributedFESpace,reffe::Tuple{<:ReferenceFEName,Any,Any},constraint
 )
+  isnothing(constraint) && return F
   args = reffe[2]
   order = maximum(args[2])
   _add_distributed_constraint(F,order,constraint)
@@ -648,6 +650,7 @@ end
 function _add_distributed_constraint(
   F::DistributedFESpace,cell_reffe::AbstractArray,constraint
 )
+  isnothing(constraint) && return F
   reffe = map(cell_reffe) do cell_reffe
     reffes, ctypes = compress_cell_data(cell_reffe)
     return only(reffes)
@@ -656,21 +659,19 @@ function _add_distributed_constraint(
 end
 
 function _add_distributed_constraint(F::DistributedFESpace,order::Integer,constraint)
-  if isnothing(constraint)
-    V = F
-  elseif constraint == :zeromean
+  isnothing(constraint) && return F
+  if constraint == :zeromean
     _trian = get_triangulation(F)
     model = get_background_model(_trian)
     trian = remove_ghost_cells(_trian,get_cell_gids(model))
     dΩ = Measure(trian,order)
-    V = ZeroMeanFESpace(F,dΩ)
+    return ZeroMeanFESpace(F,dΩ)
   else
     @unreachable """\n
     The passed option constraint=$constraint is not valid.
     Valid values for constraint: nothing, :zeromean
     """
   end
-  V
 end
 
 # Assembly

--- a/src/FESpaces.jl
+++ b/src/FESpaces.jl
@@ -651,11 +651,11 @@ function _add_distributed_constraint(
   F::DistributedFESpace,cell_reffe::AbstractArray,constraint
 )
   isnothing(constraint) && return F
-  reffe = map(cell_reffe) do cell_reffe
+  order = map(cell_reffe) do cell_reffe
     reffes, ctypes = compress_cell_data(cell_reffe)
-    return only(reffes)
+    return maximum(get_order,reffes;init=0)
   end |> getany
-  _add_distributed_constraint(F,reffe,constraint)
+  _add_distributed_constraint(F,order,constraint)
 end
 
 function _add_distributed_constraint(F::DistributedFESpace,order::Integer,constraint)


### PR DESCRIPTION
While porting to Gridap v0.20, I did not contemplate the case where the FESpace has multiple reffes. See https://github.com/gridap/GridapEmbedded.jl/pull/120