### PR TITLE
If Dirichlet DoFs, cell_to_DOFs is lazy array

### DIFF
--- a/src/Constraints.jl
+++ b/src/Constraints.jl
@@ -199,7 +199,7 @@ function generate_constraint_gids(
 end
 
 function generate_constraint_gids(
-  cell_gids::PRange, cell_to_DOFs::AbstractArray{<:Table}, DOF_is_slave, DOF_to_dof
+  cell_gids::PRange, cell_to_DOFs::AbstractArray, DOF_is_slave, DOF_to_dof
 )
   # Create pos/neg local numberings
   DOF_to_color = map(DOF_is_slave, DOF_to_dof) do DOF_is_slave, DOF_to_dof


### PR DESCRIPTION
Hello @JordiManyer,

This is a minor fix that I needed to apply to the `agfem` branch when I tested problems with Dirichlet BCs.

Lmk if you have any suggestions for improvement. Otherwise, thanks a lot for accepting the PR.

Cheers,
Eric